### PR TITLE
Allow organization secrets extraction

### DIFF
--- a/nordstream/cicd/github.py
+++ b/nordstream/cicd/github.py
@@ -164,6 +164,21 @@ class GitHub:
             raise GitHubError(response.get("message"))
         return res
 
+    def listOrganizationSecretsFromRepo(self, repo):
+        res = []
+        response = self._session.get(
+            f"{self._repoURL}/{repo}/actions/organization-secrets",
+            auth=self._auth,
+            headers=self._header,
+        ).json()
+
+        if response.get("total_count", 0) >= 0:
+            for sec in response.get("secrets"):
+                res.append(sec.get("name"))
+        else:
+            raise GitHubError(response.get("message"))
+        return res
+
     def listEnvProtections(self, repo, env):
         logger.debug("Getting environment protections")
         envReq = urllib.parse.quote(env, safe="")

--- a/nordstream/commands/github.py
+++ b/nordstream/commands/github.py
@@ -2,7 +2,7 @@
 CICD pipeline exploitation tool
 
 Usage:
-    nord-stream.py github [options] --token <ghp> --org <org> [--repo <repo> --no-repo --no-env --env <env> --disable-protections --write-filter --branch-name <name>]
+    nord-stream.py github [options] --token <ghp> --org <org> [--repo <repo> --no-repo --no-env --no-org --env <env> --disable-protections --write-filter --branch-name <name>]
     nord-stream.py github [options] --token <ghp> --org <org> --yaml <yaml> --repo <repo> [--env <env> --disable-protections --write-filter --branch-name <name>]
     nord-stream.py github [options] --token <ghp> --org <org> ([--clean-logs] [--clean-branch-policy]) [--repo <repo> --branch-name <name>]
     nord-stream.py github [options] --token <ghp> --org <org> --build-yaml <filename> --repo <repo> [--env <env> --write-filter]
@@ -29,6 +29,7 @@ args
     --env <env>                             Specify env for the yaml file creation.
     --no-repo                               Don't extract repo secrets.
     --no-env                                Don't extract environnments secrets.
+    --no-org                                Don't extract organization secrets.
     --exploit-oidc                          Generate an access token for a cloud provider using an existing OIDC trust between a cloud role and a GitHub workflow (supports only Azure for now).
     --azure-tenant-id <tenant>              Identifier of the Azure tenant associated with the application having federated credentials.
     --azure-subscription-id <subscription>  Identifier of the Azure subscription associated with the application having federated credentials.
@@ -84,6 +85,8 @@ def start(argv):
         gitHubWorkflowRunner.extractRepo = not args["--no-repo"]
     if args["--no-env"]:
         gitHubWorkflowRunner.extractEnv = not args["--no-env"]
+    if args["--no-org"]:
+        gitHubWorkflowRunner.extractOrg = not args["--no-org"]
     if args["--yaml"]:
         gitHubWorkflowRunner.yaml = args["--yaml"]
     if args["--disable-protections"]:


### PR DESCRIPTION
There are two Github APIs for listing organization secrets:
- List user organizations [[1](https://docs.github.com/en/rest/orgs/orgs?apiVersion=2022-11-28#list-organizations-for-the-authenticated-user)] then list organization secrets [[2](https://docs.github.com/en/rest/actions/secrets?apiVersion=2022-11-28#list-organization-secrets)].
- List organization secrets from user repos [[3](https://docs.github.com/en/rest/actions/secrets?apiVersion=2022-11-28#list-repository-organization-secrets)].

As the tool already enumerate repos to extract repo secrets, using the second approach for organization secrets at the same time is more effective.

[1] https://docs.github.com/en/rest/orgs/orgs?apiVersion=2022-11-28#list-organizations-for-the-authenticated-user
[2] https://docs.github.com/en/rest/actions/secrets?apiVersion=2022-11-28#list-organization-secrets
[3] https://docs.github.com/en/rest/actions/secrets?apiVersion=2022-11-28#list-repository-organization-secrets