### PR TITLE
WIP - GitLab support

### DIFF
--- a/nord-stream.py
+++ b/nord-stream.py
@@ -8,6 +8,7 @@ Usage:
 Commands
     github                                  command related to GitHub.
     devops                                  command related to Azure DevOps.
+    gitlab                                  command related to GitLab.
 
 Options:
     -h --help                               Show this screen.
@@ -33,5 +34,9 @@ if __name__ == "__main__":
         import nordstream.commands.devops as devops
 
         devops.start(argv)
+    elif args["<command>"] == "gitlab":
+        import nordstream.commands.gitlab as gitlab
+
+        gitlab.start(argv)
     else:
         logger.error(f"{args['<command>']} is not a nord-stream.py command.")

--- a/nordstream/cicd/gitlab.py
+++ b/nordstream/cicd/gitlab.py
@@ -1,0 +1,76 @@
+import requests
+from nordstream.utils.log import logger
+
+
+class GitLab:
+    _auth = None
+    _session = None
+    _token = None
+    _projects = []
+    _outputDir = "nord-stream-logs"
+    _header = None
+    # _header = {"Accept": "application/vnd.github+json"}
+
+    def __init__(self, token, org):
+        self._token = token
+        self._header = {"PRIVATE-TOKEN": token}
+        self._session = requests.Session()
+        # self._session.headers.update({"PRIVATE-TOKEN": token})
+
+    @property
+    def projects(self):
+        return self._projects
+
+    @property
+    def token(self):
+        return self._token
+
+    @classmethod
+    def checkToken(cls, token):
+        logger.verbose(f"Checking token: {token}")
+        # from https://docs.gitlab.com/ee/api/rest/index.html#personalprojectgroup-access-tokens
+        return (
+            requests.get(
+                f"https://gitlab.com/api/v4/projects",
+                headers={"PRIVATE-TOKEN": token},
+            ).status_code
+            == 200
+        )
+
+    def retieveUsernameFromToken(self):
+        logger.verbose(f"Retrieving user from token")
+        response = self._session.get(f"https://gitlab.com/api/v4/user", headers=self._header).json()
+
+        return response["username"]
+
+    def listProjects(self):
+        logger.verbose(f"Listing projects")
+
+        username = self.retieveUsernameFromToken()
+
+        response = self._session.get(f"https://gitlab.com/api/v4/users/{username}/projects", headers=self._header)
+
+        # try catch on response.status_code
+        if response.status_code == 200:
+            # Print the project names and IDs
+            for project in response.json():
+                p = {
+                    "id": project.get("id"),
+                    "path_with_namespace": project.get("path_with_namespace"),
+                    "name": project.get("name"),
+                }
+                self._projects.append(p)
+        else:
+            logger.error("Error while retrieving projects")
+            logger.debug(response.json())
+
+    def listVariablesFromProject(self, project):
+        id = project.get("id")
+        res = []
+        response = self._session.get(f"https://gitlab.com/api/v4/projects/{id}/variables", headers=self._header)
+        if response.status_code == 200:
+            # logger.debug(response.json())
+            for variable in response.json():
+                # print(variable['key'], variable['value'], variable['protected'])
+                res.append({"key": variable["key"], "value": variable["value"], "protected": variable["protected"]})
+        return res

--- a/nordstream/commands/gitlab.py
+++ b/nordstream/commands/gitlab.py
@@ -1,0 +1,53 @@
+"""
+CICD pipeline exploitation tool
+
+Usage:
+    nord-stream.py gitlab [options] --token <pat> --org <org> [--project <project>]
+
+Options:
+    -h --help                               Show this screen.
+    --version                               Show version.
+    -v, --verbose                           Verbose mode
+    -d, --debug                             Debug mode
+
+args
+    --token <pat>                           GitLab personal token
+    --list-secrets                          List all secrets.
+    --list-projects                         List all projects.
+"""
+
+from docopt import docopt
+from nordstream.cicd.gitlab import GitLab
+from nordstream.core.gitlab import GitLabRunner
+from nordstream.utils.log import logger, NordStreamLog
+
+
+def start(argv):
+    args = docopt(__doc__, argv=argv)
+
+    if args["--verbose"]:
+        NordStreamLog.setVerbosity(verbose=1)
+    if args["--debug"]:
+        NordStreamLog.setVerbosity(verbose=2)
+
+    logger.debug(args)
+
+    # check validity of the token
+    if not GitLab.checkToken(args["--token"]):
+        logger.critical("Invalid token")
+
+    # gitlab setup
+    gitlab = GitLab(args["--token"], args["--org"])
+    gitLabRunner = GitLabRunner(gitlab)
+
+    gitLabRunner.getProjects(args["--project"])
+
+    # # logic
+    if args["--list-projects"]:
+        gitLabRunner.listGitLabProjects()
+
+    elif args["--list-secrets"]:
+        gitLabRunner.listGitLabSecrets()
+
+    else:
+        gitLabRunner.runPipeline()

--- a/nordstream/core/gitlab.py
+++ b/nordstream/core/gitlab.py
@@ -1,0 +1,51 @@
+import logging
+
+from os.path import exists
+from nordstream.git import *
+
+
+class GitLabRunner:
+    _cicd = None
+
+    def __init__(self, cicd):
+        self._cicd = cicd
+
+    def getProjects(self, project):
+        if project:
+            logger.info("TODO")
+            # # if repo is a file, read it
+            # if exists(project):
+            #     with open(project, "r") as file:
+            #         for project in file:
+            #             #TODO
+            #             # self._cicd.addProject(project.strip())
+        else:
+            self._cicd.listProjects()
+
+    def listGitLabSecrets(self):
+        logger.info("Listing GitLab secrets")
+        for project in self._cicd.projects:
+            try:
+                self.__displayProjectVariables(project)
+            except Exception as e:
+                logger.error(f"Error while listing secrets for {project.name}: {e}")
+
+    def __displayProjectVariables(self, project):
+        variables = self._cicd.listVariablesFromProject(project)
+        if len(variables) != 0:
+            logger.info("Project variables:")
+            for variable in variables:
+                value = variable.get("value")
+                protected = variable.get("protected")
+                logger.raw(
+                    f'\t- {variable["key"]}={variable["value"]} protected:{variable["protected"]}\n', logging.INFO
+                )
+
+    def listGitLabProjects(self):
+        logger.info("Listing GitLab projects")
+        for project in self._cicd.projects:
+            logger.raw(f'- {project["name"]}\n', level=logging.INFO)
+
+    def runPipeline(self):
+        # TODO
+        logger.debug("TODO")


### PR DESCRIPTION
Add GitLab CI/CD support.

- [ ] List projects variables. 
- [ ] List vault secrets.

According to gitlab documentation: https://docs.gitlab.com/ee/ci/variables/#define-a-cicd-variable-in-the-ui
"Sensitive variables like tokens or passwords should be stored in the settings in the UI".
A variable can optionally be masked: "If selected, the variable’s Value is masked in job logs"
By using the Gitlab API it's possible for the project owner to retrieve variables data, including their values.

Using external Vault server is another way to manage secrets https://docs.gitlab.com/ee/ci/secrets/
"This sensitive information can be items like API tokens, database credentials, or private keys."
