### PR TITLE
GitLab: implement --list-runners through project jobs (unprivileged)

### DIFF
--- a/nordstream/cicd/gitlab.py
+++ b/nordstream/cicd/gitlab.py
@@ -139,6 +139,50 @@ class GitLab:
 
         return response.status_code, res
 
+    def listRunnersFromProject(self, project):
+        id = project.get("id")
+        res = []
+
+        status_code, response = self.__paginatedGet(f"{self._gitlabURL}/api/v4/projects/{id}/jobs")
+
+        if status_code == 200 and len(response) > 0:
+            for job in response:
+
+                if not job.get("runner") or not job.get("runner_manager"):
+                    continue
+
+                # Get executor from job trace
+                executor = "unknown"
+                response = self._session.get(f"{self._gitlabURL}/api/v4/projects/{id}/jobs/{job['id']}/trace")
+                if response.status_code == 200 and len(response.text) > 0:
+                    regex = r'Preparing the "([^"]+)" executor'
+                    match = re.search(r'Preparing the "([^"]+)" executor', response.text)
+                    if match:
+                        executor = match.group(1)
+
+                _runner = job["runner"]
+                _manager = job["runner_manager"]
+                res.append({
+                    "id": f"{_runner['id']}/{_manager['system_id']}",
+                    "status": _manager["status"],
+                    "contacted_at": _manager["contacted_at"],
+                    "runner_type": _runner["runner_type"],
+                    "access_level": "unknown",
+                    "executor": executor,
+                    "description": _runner["description"],
+                    "platform": _manager["platform"],
+                    "architecture": _manager["architecture"],
+                    "ip_address": _manager["ip_address"],
+                    "version": _manager["version"],
+                    "projects": [project["path_with_namespace"]],
+                    "tags": job["tag_list"],
+                })
+
+        elif status_code == 403:
+            raise GitLabError(response.get("message"))
+
+        return res
+
     def listVariablesFromProject(self, project):
         id = project.get("id")
         res = []

--- a/nordstream/commands/gitlab.py
+++ b/nordstream/commands/gitlab.py
@@ -3,7 +3,7 @@ CICD pipeline exploitation tool
 
 Usage:
     nord-stream gitlab [options] --token <pat> (--list-secrets | --list-protections) [--project <project> --group <group> --no-project --no-group --no-instance --write-filter --sleep <seconds>]
-    nord-stream gitlab [options] --token <pat> ( --list-groups | --list-projects | --list-users) [--project <project> --group <group> --write-filter]
+    nord-stream gitlab [options] --token <pat> ( --list-groups | --list-projects | --list-users | --list-runners) [--project <project> --group <group> --write-filter]
     nord-stream gitlab [options] --token <pat> --yaml <yaml> --project <project> [--project-path <path> --no-clean]
     nord-stream gitlab [options] --token <pat> --clean-logs [--project <project>]
     nord-stream gitlab [options] --token <pat> --describe-token
@@ -32,6 +32,7 @@ args:
     --list-projects                         List all projects.
     --list-groups                           List all groups.
     --list-users                            List all users.
+    --list-runners                          List runners through project jobs (unprivileged, but non-exhaustive).
     --write-filter                          Filter repo where current user has developer access or more.
     --no-project                            Don't extract project secrets.
     --no-group                              Don't extract group secrets.
@@ -128,6 +129,14 @@ def start(argv):
 
     elif args["--list-users"]:
         gitLabRunner.listGitLabUsers()
+
+    elif args["--list-runners"]:
+        if gitLabRunner.extractProject:
+            gitLabRunner.getProjects(args["--project"], membership=args["--membership"])
+        if gitLabRunner.extractGroup:
+            gitLabRunner.getGroups(args["--group"])
+
+        gitLabRunner.listGitLabRunners()
 
     elif args["--list-secrets"]:
         if gitLabRunner.extractProject:

--- a/nordstream/core/gitlab/gitlab.py
+++ b/nordstream/core/gitlab/gitlab.py
@@ -3,6 +3,7 @@ import logging
 from urllib.parse import urlparse
 from os import makedirs, chdir
 from os.path import exists, realpath
+from datetime import datetime
 from nordstream.utils.log import logger
 from nordstream.git import Git
 import subprocess
@@ -143,6 +144,70 @@ class GitLabRunner:
 
         if len(self._cicd.groups) == 0:
             logger.error("No group found.")
+
+    def listGitLabRunners(self):
+        logger.info("Listing GitLab runners")
+
+        res = False
+        if self._extractProject:
+            res |= self.__listGitLabProjectRunners()
+
+        if not res:
+            logger.warning(
+                "You don't have access to any runner or job"
+            )
+
+    def __mergeLists(self, current, new, key):
+        current[key] = list(set(current[key] + new[key]))
+        new[key] = current[key]
+
+    def __mergeRunners(self, current, new):
+        for runner in new:
+            existing = next((c for c in current if c["id"] == runner["id"]), None)
+            if not existing:
+                current.append(runner)
+                continue
+
+            date = lambda d: datetime.strptime(d, "%Y-%m-%dT%H:%M:%S.%fZ")
+            self.__mergeLists(existing, runner, "projects")
+            self.__mergeLists(existing, runner, "tags")
+            if date(runner["contacted_at"]) > date(existing["contacted_at"]):
+                existing.update(runner)
+
+    def __listGitLabProjectRunners(self):
+        res = False
+        runners = []
+        for project in self._cicd.projects:
+            self.__mergeRunners(runners, self._cicd.listRunnersFromProject(project))
+
+        for runner in runners:
+            res = True
+            logger.info(f'{runner["id"]} (scope: {runner["runner_type"].replace("_type", "")}, executor: {runner["executor"]}, accesslevel: {runner["access_level"]})')
+            logger.raw(
+                f'    - status: {runner["status"].lower()} (lastseen: {runner["contacted_at"]})\n',
+                logging.INFO)
+            logger.raw(
+                f'    - description: {runner["description"] or "n/a"}\n',
+                logging.INFO)
+            logger.raw(
+                f'    - tags: {runner["tags"]}\n',
+                logging.INFO)
+            logger.raw(
+                f'    - platform: {runner["platform"]} ({runner["architecture"]})\n',
+                logging.INFO)
+            logger.raw(
+                f'    - ipaddress: {runner["ip_address"]}\n',
+                logging.INFO)
+            if runner["projects"]:
+                logger.raw(
+                    f'    - projects:\n',
+                    logging.INFO)
+                for project in runner["projects"]:
+                    logger.raw(
+                        f'      - {project}\n',
+                        logging.INFO)
+
+        return res
 
     def listGitLabSecrets(self):
         logger.info("Listing GitLab secrets")


### PR DESCRIPTION
Users with at least Guest privileges are able to list project pipelines & jobs through the API. Jobs information describes the runner and runner_manager having handled a job, allowing to get a non-exhaustive list of runners from the projects the user has access to.

Almost all data is retrieved from the `/projects/:id/jobs` endpoint, in addition to `/projects/:id/jobs/:id/trace` to get the executor mode.

This method may generate a lot of traffic on large GitLab instances.

```
$ nord-stream gitlab --url https://gitlab --token "$PAT" --list-runners
[*] Listing GitLab runners
[*] 1/r_N7xKp2QdLz8f (scope: instance, executor: docker, accesslevel: unknown)
    - status: online (lastseen: 2026-01-25T16:11:13.547Z)
    - description: n/a
    - tags: []
    - platform: linux (amd64)
    - ipaddress: 172.17.0.2
    - projects:
      - test/awesome-project
      - test/super-app
      - common/config
[*] 2/r_4Jt9WcHsE1Ya (scope: project, executor: shell, accesslevel: unknown)
    - status: online (lastseen: 2026-01-25T17:42:05.987Z)
    - description: n/a
    - tags: ['prod']
    - platform: linux (amd64)
    - ipaddress: 172.17.0.3
    - projects:
      - test/cicd
```