### PR TITLE
feat(devops): add pipeline-file option

### DIFF
--- a/nordstream/commands/devops.py
+++ b/nordstream/commands/devops.py
@@ -2,8 +2,8 @@
 CICD pipeline exploitation tool
 
 Usage:
-    nord-stream devops [options] --token <pat> --org <org> [extraction] [--project <project> --write-filter --no-clean --branch-name <name> --pipeline-name <name> --repo-name <name>]
-    nord-stream devops [options] --token <pat> --org <org> --yaml <yaml> --project <project> [--write-filter --no-clean --branch-name <name> --pipeline-name <name> --repo-name <name>]
+    nord-stream devops [options] --token <pat> --org <org> [extraction] [--project <project> --write-filter --no-clean --branch-name <name> --pipeline-name <name> --pipeline-file <filename> --repo-name <name>]
+    nord-stream devops [options] --token <pat> --org <org> --yaml <yaml> --project <project> [--write-filter --no-clean --branch-name <name> --pipeline-name <name> --pipeline-file <filename> --repo-name <name>]
     nord-stream devops [options] --token <pat> --org <org> --build-yaml <output> [--build-type <type>]
     nord-stream devops [options] --token <pat> --org <org> --clean-logs [--project <project>]
     nord-stream devops [options] --token <pat> --org <org> --list-projects [--write-filter]
@@ -41,6 +41,7 @@ args:
     --describe-token                        Display information on the token
     --branch-name <name>                    Use specific branch name for deployment.
     --pipeline-name <name>                  Use pipeline for deployment.
+    --pipeline-file <filename>              Pipeline filename (default: azure-pipelines.yml).
     --repo-name <name>                      Use specific repo for deployment.
 
 Exctraction:
@@ -58,10 +59,11 @@ Authors: @hugow @0hexit
 """
 
 from docopt import docopt
+
 from nordstream.cicd.devops import DevOps
 from nordstream.core.devops.devops import DevOpsRunner
-from nordstream.utils.log import logger, NordStreamLog
 from nordstream.git import Git
+from nordstream.utils.log import NordStreamLog, logger
 
 
 def start(argv):
@@ -97,7 +99,8 @@ def start(argv):
         Git.USER = args["--user"]
     if args["--email"]:
         Git.EMAIL = args["--email"]
-
+    if args["--pipeline-file"]:
+        devopsRunner.pipelineFilename = args["--pipeline-file"]
     if args["--yaml"]:
         devopsRunner.yaml = args["--yaml"]
     if args["--write-filter"]:

--- a/nordstream/core/devops/devops.py
+++ b/nordstream/core/devops/devops.py
@@ -1,15 +1,15 @@
-import logging
 import base64
-import time
-
-from os import makedirs, chdir
-from os.path import exists, realpath
-from nordstream.yaml.devops import DevOpsPipelineGenerator
-from nordstream.utils.errors import GitError, RepoCreationError, DevOpsError
-from nordstream.utils.log import logger
-from nordstream.utils.helpers import isAllowed
-from nordstream.git import Git
+import logging
 import subprocess
+import time
+from os import chdir, makedirs
+from os.path import exists, realpath
+
+from nordstream.git import Git
+from nordstream.utils.errors import DevOpsError, GitError, RepoCreationError
+from nordstream.utils.helpers import isAllowed
+from nordstream.utils.log import logger
+from nordstream.yaml.devops import DevOpsPipelineGenerator
 
 
 class DevOpsRunner:
@@ -114,6 +114,14 @@ class DevOpsRunner:
     @yaml.setter
     def yaml(self, value):
         self._yaml = realpath(value)
+
+    @property
+    def pipelineFilename(self):
+        return self._pipelineFilename
+
+    @pipelineFilename.setter
+    def pipelineFilename(self, value):
+        self._pipelineFilename = value
 
     @property
     def writeAccessFilter(self):
@@ -597,7 +605,7 @@ class DevOpsRunner:
         Git.gitCreateDummyFile("README.md")
         diffOutput = Git.gitDiffFile("README.md")
         stdout, stderr = diffOutput.communicate()
-        if stdout == b'':
+        if stdout == b"":
             logger.info(f"README.md file not modified.")
         else:
             logger.info(f"README.md file is modified, incrementing commit count.")


### PR DESCRIPTION
This exposes the name of the pipeline file to the CLI in case the file is not azure-pipelines.yml for some reason.

Side note: I think the pre-commit hooks need to be updated, specifically `black`, since `ast` doesn't have `Str` anymore and the version pinned here is old and doesn't support python 3.12+. Sorry for the import reorder and the random `b=""` but that was the effect of trying to get `black` to pass the hook.